### PR TITLE
New IAsset.Copy extension and MediaProcessorNames constants

### DIFF
--- a/MediaServices.Client.Extensions.Tests/App.config
+++ b/MediaServices.Client.Extensions.Tests/App.config
@@ -9,17 +9,22 @@
     <add key="MediaServicesUri" value="https://media.windows.net/" />
     <add key="MediaServicesAcsBaseAddress" value="https://wamsprodglobal001acs.accesscontrol.windows.net" />
     <add key="MediaServicesAccessScope" value="urn:WindowsAzureMediaServices" />
+
+    <add key="MediaServiceFragBlobAssetId" value="%MediaServiceFragBlobAssetId%" />
+
+    <add key="MediaServiceStorageAccountName" value="%MediaServiceStorageAccountName%" />
+    <add key="MediaServiceStorageAccountKey" value="%MediaServiceStorageAccountKey%" />
   </appSettings>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30AD4FE6B2A6AEED" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-6.0.6.0" newVersion="6.0.6.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31BF3856AD364E35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-4.3.0.0" newVersion="4.3.0.0" />
-			</dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30AD4FE6B2A6AEED" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.6.0" newVersion="6.0.6.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31BF3856AD364E35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.3.0.0" newVersion="4.3.0.0" />
+      </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Spatial" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-5.6.3.0" newVersion="5.6.3.0" />
@@ -52,5 +57,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-
 </configuration>

--- a/MediaServices.Client.Extensions.Tests/TestHelper.cs
+++ b/MediaServices.Client.Extensions.Tests/TestHelper.cs
@@ -1,4 +1,3 @@
-﻿
 ﻿// <copyright file="TestHelper.cs" company="Microsoft">Copyright 2013 Microsoft Corporation</copyright>
 // <license>
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,13 +15,21 @@
 
 namespace MediaServices.Client.Extensions.Tests
 {
-    
-﻿using System;
+    using System;
     using System.Configuration;
-    using Microsoft.WindowsAzure.MediaServices.Client;
+    ﻿using Microsoft.WindowsAzure.MediaServices.Client;
+    using Microsoft.WindowsAzure.Storage.Auth;
 
     public class TestHelper
     {
+        public static string FragBlobAssetId
+        {
+            get
+            {
+                return ConfigurationManager.AppSettings["MediaServiceFragBlobAssetId"];
+            }
+        }
+
         public static CloudMediaContext CreateContext()
         {
             return new CloudMediaContext(
@@ -30,8 +37,14 @@ namespace MediaServices.Client.Extensions.Tests
                 ConfigurationManager.AppSettings["MediaServiceAccountName"],
                 ConfigurationManager.AppSettings["MediaServiceAccountKey"],
                 ConfigurationManager.AppSettings["MediaServicesAccessScope"],
-                ConfigurationManager.AppSettings["MediaServicesAcsBaseAddress"]
-                );
+                ConfigurationManager.AppSettings["MediaServicesAcsBaseAddress"]);
+        }
+
+        public static StorageCredentials CreateStorageCredentials()
+        {
+            return new StorageCredentials(
+                ConfigurationManager.AppSettings["MediaServiceStorageAccountName"],
+                ConfigurationManager.AppSettings["MediaServiceStorageAccountKey"]);
         }
     }
 }

--- a/MediaServices.Client.Extensions/IAssetFileExtensions.cs
+++ b/MediaServices.Client.Extensions/IAssetFileExtensions.cs
@@ -30,12 +30,12 @@ namespace Microsoft.WindowsAzure.MediaServices.Client
     public static class IAssetFileExtensions
     {
         /// <summary>
-        /// Returns a <see cref="System.Threading.Tasks.Task&lt;AssetFileMetadata&gt;"/> instance to retreive the <paramref name="assetFile"/> metadata.
+        /// Returns a <see cref="System.Threading.Tasks.Task&lt;AssetFileMetadata&gt;"/> instance to retrieve the <paramref name="assetFile"/> metadata.
         /// </summary>
         /// <param name="assetFile">The <see cref="IAssetFile"/> instance from where to get the metadata.</param>
         /// <param name="sasLocator">The <see cref="ILocator"/> instance.</param>
         /// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> instance used for cancellation.</param>
-        /// <returns>A <see cref="System.Threading.Tasks.Task&lt;AssetFileMetadata&gt;"/> instance to retreive the <paramref name="assetFile"/> metadata.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task&lt;AssetFileMetadata&gt;"/> instance to retrieve the <paramref name="assetFile"/> metadata.</returns>
         public static async Task<AssetFileMetadata> GetMetadataAsync(this IAssetFile assetFile, ILocator sasLocator, CancellationToken cancellationToken)
         {
             if (assetFile == null)

--- a/MediaServices.Client.Extensions/MediaProcessorNames.cs
+++ b/MediaServices.Client.Extensions/MediaProcessorNames.cs
@@ -31,6 +31,21 @@ namespace Microsoft.WindowsAzure.MediaServices.Client
         public const string AzureMediaEncoder = "Azure Media Encoder";
 
         /// <summary>
+        ///  Lets you run encoding tasks using the proccessor 'Azure Media Indexer'.
+        /// </summary>
+        public const string AzureMediaIndexer = "Azure Media Indexer";
+
+        /// <summary>
+        ///  Lets you run encoding tasks using the proccessor 'Azure Media Hyperlapse'.
+        /// </summary>
+        public const string AzureMediaHyperlapse = "Azure Media Hyperlapse";
+
+        /// <summary>
+        ///  Lets you run encoding tasks using the proccessor 'Media Encoder Premium Workflow'.
+        /// </summary>
+        public const string MediaEncoderPremiumWorkflow = "Media Encoder Premium Workflow";
+
+        /// <summary>
         /// Lets you convert media assets from MP4 to Smooth Streaming format. Also, lets you convert media assets 
         /// from Smooth Streaming to the Apple HTTP Live Streaming (HLS) format.
         /// </summary>

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ IAsset asset = context.Assets.CreateFromFolder(folderPath, assetCreationOptions)
 ```
 
 ### Copy an Asset
-Copies the all files in the source asset into into the destination asset using a single extension method for the [IAsset](http://msdn.microsoft.com/library/microsoft.windowsazure.mediaservices.client.iasset.aspx) interface. The source asset and the destination asset can belong to different Media Services accounts. There is an additional overload with _async_ support.
+Copies the all files in the source asset into into the destination asset using a single extension method for the [IAsset](http://msdn.microsoft.com/library/microsoft.windowsazure.mediaservices.client.iasset.aspx) interface. The source and destination assets can belong to different Media Services accounts. There is an additional overload with _async_ support.
 
 ```csharphttps://github.com/mconverti/azure-sdk-for-media-services-extensions-1/edit/dev/README.md#
 CloudMediaContext context = new CloudMediaContext("%accountName%", "%accountKey%");

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Copies the all files in the source asset into the destination asset using a sing
 This extension method works with:
 * Regular assets
 * Live archive assets (FragBlob format)
-* Source and destination assets can belong to different Media Services accounts (even across different datacenters)
+* Source and destination assets belonging to different Media Services accounts (even across different datacenters)
 
 ```csharphttps://github.com/mconverti/azure-sdk-for-media-services-extensions-1/edit/dev/README.md#
 CloudMediaContext context = new CloudMediaContext("%accountName%", "%accountKey%");

--- a/README.md
+++ b/README.md
@@ -60,12 +60,12 @@ IAsset asset = context.Assets.CreateFromFolder(folderPath, assetCreationOptions)
 ```
 
 ### Copy an Asset
-Copies the all files in the source asset into the destination asset using a single extension method for the [IAsset](http://msdn.microsoft.com/library/microsoft.windowsazure.mediaservices.client.iasset.aspx) interface. The source and destination assets can belong to different Media Services accounts. There is an additional overload with _async_ support.
+Copies the all files in the source asset into the destination asset using a single extension method for the [IAsset](http://msdn.microsoft.com/library/microsoft.windowsazure.mediaservices.client.iasset.aspx) interface. There is an additional overload with _async_ support.
 
 This extension method works with:
 * Regular assets
 * Live archive assets (FragBlob format)
-* Source and destination assets in different Media Services account (even across  different datacenters)
+* Source and destination assets can belong to different Media Services accounts (even across different datacenters)
 
 ```csharphttps://github.com/mconverti/azure-sdk-for-media-services-extensions-1/edit/dev/README.md#
 CloudMediaContext context = new CloudMediaContext("%accountName%", "%accountKey%");

--- a/README.md
+++ b/README.md
@@ -60,7 +60,12 @@ IAsset asset = context.Assets.CreateFromFolder(folderPath, assetCreationOptions)
 ```
 
 ### Copy an Asset
-Copies the all files in the source asset into into the destination asset using a single extension method for the [IAsset](http://msdn.microsoft.com/library/microsoft.windowsazure.mediaservices.client.iasset.aspx) interface. The source and destination assets can belong to different Media Services accounts. There is an additional overload with _async_ support.
+Copies the all files in the source asset into the destination asset using a single extension method for the [IAsset](http://msdn.microsoft.com/library/microsoft.windowsazure.mediaservices.client.iasset.aspx) interface. The source and destination assets can belong to different Media Services accounts. There is an additional overload with _async_ support.
+
+This extension method works with:
+* Regular assets
+* Live archive assets (FragBlob format)
+* Source and destination assets in different Media Services account (even across  different datacenters)
 
 ```csharphttps://github.com/mconverti/azure-sdk-for-media-services-extensions-1/edit/dev/README.md#
 CloudMediaContext context = new CloudMediaContext("%accountName%", "%accountKey%");

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Windows Azure Media Services .NET SDK Extensions
 ================================================
 
 ## What is it?
-A NuGet package that contains a set of extension methods and helpers for the Windows Azure Media Services SDK for .NET.
+A NuGet package that contains a set of extension methods and helpers for the [Windows Azure Media Services .NET SDK](https://github.com/mconverti/azure-sdk-for-media-services).
 
 ## Usage
 Install the [WindowsAzure.MediaServices.Extensions](https://www.nuget.org/packages/WindowsAzure.MediaServices.Extensions) Nuget package by running `Install-Package WindowsAzure.MediaServices.Extensions` in the [Package Manager Console](http://docs.nuget.org/docs/start-here/using-the-package-manager-console/).
@@ -57,6 +57,24 @@ AssetCreationOptions assetCreationOptions = AssetCreationOptions.None;
 
 // Create a new asset and upload all the files in a local folder using a single extension method.
 IAsset asset = context.Assets.CreateFromFolder(folderPath, assetCreationOptions);
+```
+
+### Copy an Asset
+Copies the all files in the source asset into into the destination asset using a single extension method for the [IAsset](http://msdn.microsoft.com/library/microsoft.windowsazure.mediaservices.client.iasset.aspx) interface. The source asset and the destination asset can belong to different Media Services accounts. There is an additional overload with _async_ support.
+
+```csharphttps://github.com/mconverti/azure-sdk-for-media-services-extensions-1/edit/dev/README.md#
+CloudMediaContext context = new CloudMediaContext("%accountName%", "%accountKey%");
+
+// Get a reference to the source asset.
+string sourceAssetId = "%sourceAssetId%";
+IAsset sourceAsset = context.Assets.Where(a => a.Id == sourceAssetId).First();
+
+// Create an empty destination asset where the source asset files are going to be copied.
+IAsset destinationAsset = context.Assets.Create("Asset Copy", AssetCreationOptions.None);
+StorageCredentials destinationStorageCredentials = new StorageCredentials("%storageAccountName%", "%storageAccountKey%");
+
+// Copy the files in the 'sourceAsset' instance into the 'destinationAsset' instance.
+sourceAsset.Copy(destinationAsset, destinationStorageCredentials);
 ```
 
 ### Generate Asset Files from Blob storage
@@ -254,10 +272,16 @@ Get the latest version of a media processor filtering by its name using a single
 CloudMediaContext context = new CloudMediaContext("%accountName%", "%accountKey%");
 
 // The media processor name.
-string mediaProcessorName = MediaProcessorNames.WindowsAzureMediaEncoder;
+string azureMediaEncoderProcessorName = MediaProcessorNames.AzureMediaEncoder;
+string azureMediaIndexerProcessorName = MediaProcessorNames.AzureMediaIndexer;
+string azureMediaHyperlapseProcessorName = MediaProcessorNames.AzureMediaHyperlapse;
+string mediaEncoderPremiumWorkflowProcessorName = MediaProcessorNames.MediaEncoderPremiumWorkflow;
 
 // Get the latest version of a media processor by its name using a single extension method.
-IMediaProcessor processor = context.MediaProcessors.GetLatestMediaProcessorByName(mediaProcessorName);
+IMediaProcessor azureMediaEncoderProcessor = context.MediaProcessors.GetLatestMediaProcessorByName(azureMediaEncoderProcessorName);
+IMediaProcessor azureMediaIndexerProcessor = context.MediaProcessors.GetLatestMediaProcessorByName(azureMediaIndexerProcessorName);
+IMediaProcessor azureMediaHyperlapseProcessor = context.MediaProcessors.GetLatestMediaProcessorByName(azureMediaHyperlapseProcessorName);
+IMediaProcessor mediaEncoderPremiumWorkflowProcessor = context.MediaProcessors.GetLatestMediaProcessorByName(mediaEncoderPremiumWorkflowProcessorName);
 ```
 
 ### Create a Job with a single Task


### PR DESCRIPTION
* Added new extension methods for IAsset to copy all its files into another asset
* Added new media processors names to the MediaProcessorNames class: 'Azure Media Indexer', 'Azure Media Hyperlapse', 'Media Encoder Premium Workflow'
* Updated Readme.md documentation
