### PR TITLE
Updated Media Processor names

### DIFF
--- a/.nuget/windowsazure.mediaservices.extensions.nuspec
+++ b/.nuget/windowsazure.mediaservices.extensions.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>windowsazure.mediaservices.extensions</id>
-    <version>3.3.0.0</version>
+    <version>3.5.1.0</version>
     <title>Windows Azure Media Services .NET SDK Extensions</title>
     <authors>Microsoft Corporation</authors>
     <owners>Microsoft Corporation</owners>
@@ -22,7 +22,7 @@
       <dependency id="TransientFaultHandling.Core" version="5.1.1209.1" />
       <dependency id="WindowsAzure.Storage" version="4.3.0.0" />
       <dependency id="Newtonsoft.Json" version="6.0.8.0" />
-      <dependency id="WindowsAzure.MediaServices" version="3.3.0.0" />
+      <dependency id="WindowsAzure.MediaServices" version="3.5.1.0" />
     </dependencies>
   </metadata>
 </package>

--- a/MediaServices.Client.Extensions.Tests/MediaServices.Client.Extensions.Tests.csproj
+++ b/MediaServices.Client.Extensions.Tests/MediaServices.Client.Extensions.Tests.csproj
@@ -55,16 +55,16 @@
       <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.3.1.0\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.MediaServices.Client, Version=3.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\windowsazure.mediaservices.3.3.0.0\lib\net45\Microsoft.WindowsAzure.MediaServices.Client.dll</HintPath>
+    <Reference Include="Microsoft.WindowsAzure.MediaServices.Client, Version=3.5.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\windowsazure.mediaservices.3.5.1.0\lib\net45\Microsoft.WindowsAzure.MediaServices.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.MediaServices.Client.Common.BlobTransfer, Version=3.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\windowsazure.mediaservices.3.3.0.0\lib\net45\Microsoft.WindowsAzure.MediaServices.Client.Common.BlobTransfer.dll</HintPath>
+    <Reference Include="Microsoft.WindowsAzure.MediaServices.Client.Common.BlobTransfer, Version=3.5.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\windowsazure.mediaservices.3.5.1.0\lib\net45\Microsoft.WindowsAzure.MediaServices.Client.Common.BlobTransfer.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.MediaServices.Client.Common.FileEncryption, Version=3.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\windowsazure.mediaservices.3.3.0.0\lib\net45\Microsoft.WindowsAzure.MediaServices.Client.Common.FileEncryption.dll</HintPath>
+    <Reference Include="Microsoft.WindowsAzure.MediaServices.Client.Common.FileEncryption, Version=3.5.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\windowsazure.mediaservices.3.5.1.0\lib\net45\Microsoft.WindowsAzure.MediaServices.Client.Common.FileEncryption.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Storage, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/MediaServices.Client.Extensions.Tests/Mocks/MediaContextBaseMock.cs
+++ b/MediaServices.Client.Extensions.Tests/Mocks/MediaContextBaseMock.cs
@@ -63,6 +63,6 @@ namespace MediaServices.Client.Extensions.Tests.Mocks
         public override MediaProcessorBaseCollection MediaProcessors { get { throw new NotImplementedException(); } }
         public override NotificationEndPointCollection NotificationEndPoints { get { throw new NotImplementedException(); } }
         public override StorageAccountBaseCollection StorageAccounts { get { return _storageAccounts; } }
-
+        public override StreamingFilterBaseCollection Filters { get { throw new NotImplementedException(); } }
     }
 }

--- a/MediaServices.Client.Extensions.Tests/Properties/AssemblyInfo.cs
+++ b/MediaServices.Client.Extensions.Tests/Properties/AssemblyInfo.cs
@@ -46,5 +46,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.3.0.0")]
-[assembly: AssemblyFileVersion("3.3.0.0")]
+[assembly: AssemblyVersion("3.5.1.0")]
+[assembly: AssemblyFileVersion("3.5.1.0")]

--- a/MediaServices.Client.Extensions.Tests/packages.config
+++ b/MediaServices.Client.Extensions.Tests/packages.config
@@ -9,6 +9,6 @@
   <package id="System.IdentityModel.Tokens.Jwt" version="4.0.2.205111437" targetFramework="net45" />
   <package id="System.Spatial" version="5.6.4" targetFramework="net45" />
   <package id="TransientFaultHandling.Core" version="5.1.1209.1" targetFramework="net40" />
-  <package id="windowsazure.mediaservices" version="3.3.0.0" targetFramework="net45" />
+  <package id="windowsazure.mediaservices" version="3.5.1.0" targetFramework="net45" />
   <package id="WindowsAzure.Storage" version="4.3.0.0" targetFramework="net40" />
 </packages>

--- a/MediaServices.Client.Extensions/MediaProcessorNames.cs
+++ b/MediaServices.Client.Extensions/MediaProcessorNames.cs
@@ -15,33 +15,41 @@
 
 namespace Microsoft.WindowsAzure.MediaServices.Client
 {
+    using System;
+
     /// <summary>
     /// Contains string constants with the available media processors' names.
     /// </summary>
     public static class MediaProcessorNames
     {
         /// <summary>
-        /// Lets you run encoding tasks using the proccessor 'Windows Azure Media Encoder'.
+        /// Lets you run encoding tasks using the processor 'Windows Azure Media Encoder'.
         /// </summary>
+        [Obsolete]
         public const string WindowsAzureMediaEncoder = "Windows Azure Media Encoder";
 
         /// <summary>
-        ///  Lets you run encoding tasks using the proccessor 'Azure Media Encoder'.
+        ///  Lets you run encoding tasks using the processor 'Azure Media Encoder'.
         /// </summary>
         public const string AzureMediaEncoder = "Azure Media Encoder";
 
         /// <summary>
-        ///  Lets you run encoding tasks using the proccessor 'Azure Media Indexer'.
+        ///  Lets you run encoding tasks using the processor 'Azure Media Indexer'.
         /// </summary>
         public const string AzureMediaIndexer = "Azure Media Indexer";
 
         /// <summary>
-        ///  Lets you run encoding tasks using the proccessor 'Azure Media Hyperlapse'.
+        ///  Lets you run encoding tasks using the processor 'Azure Media Hyperlapse'.
         /// </summary>
         public const string AzureMediaHyperlapse = "Azure Media Hyperlapse";
 
         /// <summary>
-        ///  Lets you run encoding tasks using the proccessor 'Media Encoder Premium Workflow'.
+        ///  Lets you run encoding tasks using the processor 'Media Encoder Standard'.
+        /// </summary>
+        public const string MediaEncoderStandard = "Media Encoder Standard";
+
+        /// <summary>
+        ///  Lets you run encoding tasks using the processor 'Media Encoder Premium Workflow'.
         /// </summary>
         public const string MediaEncoderPremiumWorkflow = "Media Encoder Premium Workflow";
 

--- a/MediaServices.Client.Extensions/MediaServices.Client.Extensions.csproj
+++ b/MediaServices.Client.Extensions/MediaServices.Client.Extensions.csproj
@@ -70,16 +70,16 @@
       <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.1.8.0.0\lib\net35-full\Microsoft.WindowsAzure.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.MediaServices.Client, Version=3.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\windowsazure.mediaservices.3.3.0.0\lib\net45\Microsoft.WindowsAzure.MediaServices.Client.dll</HintPath>
+    <Reference Include="Microsoft.WindowsAzure.MediaServices.Client, Version=3.5.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\windowsazure.mediaservices.3.5.1.0\lib\net45\Microsoft.WindowsAzure.MediaServices.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.MediaServices.Client.Common.BlobTransfer, Version=3.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\windowsazure.mediaservices.3.3.0.0\lib\net45\Microsoft.WindowsAzure.MediaServices.Client.Common.BlobTransfer.dll</HintPath>
+    <Reference Include="Microsoft.WindowsAzure.MediaServices.Client.Common.BlobTransfer, Version=3.5.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\windowsazure.mediaservices.3.5.1.0\lib\net45\Microsoft.WindowsAzure.MediaServices.Client.Common.BlobTransfer.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.MediaServices.Client.Common.FileEncryption, Version=3.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\windowsazure.mediaservices.3.3.0.0\lib\net45\Microsoft.WindowsAzure.MediaServices.Client.Common.FileEncryption.dll</HintPath>
+    <Reference Include="Microsoft.WindowsAzure.MediaServices.Client.Common.FileEncryption, Version=3.5.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\windowsazure.mediaservices.3.5.1.0\lib\net45\Microsoft.WindowsAzure.MediaServices.Client.Common.FileEncryption.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Storage, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/MediaServices.Client.Extensions/Properties/AssemblyInfo.cs
+++ b/MediaServices.Client.Extensions/Properties/AssemblyInfo.cs
@@ -47,5 +47,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.3.0.0")]
-[assembly: AssemblyFileVersion("3.3.0.0")]
+[assembly: AssemblyVersion("3.5.1.0")]
+[assembly: AssemblyFileVersion("3.5.1.0")]

--- a/MediaServices.Client.Extensions/packages.config
+++ b/MediaServices.Client.Extensions/packages.config
@@ -8,6 +8,6 @@
   <package id="System.IdentityModel.Tokens.Jwt" version="4.0.2.205111437" targetFramework="net45" />
   <package id="System.Spatial" version="5.6.4" targetFramework="net45" />
   <package id="TransientFaultHandling.Core" version="5.1.1209.1" targetFramework="net45" />
-  <package id="windowsazure.mediaservices" version="3.3.0.0" targetFramework="net45" />
+  <package id="windowsazure.mediaservices" version="3.5.1.0" targetFramework="net45" />
   <package id="WindowsAzure.Storage" version="4.3.0" targetFramework="net45" />
 </packages>

--- a/README.md
+++ b/README.md
@@ -280,12 +280,14 @@ CloudMediaContext context = new CloudMediaContext("%accountName%", "%accountKey%
 string azureMediaEncoderProcessorName = MediaProcessorNames.AzureMediaEncoder;
 string azureMediaIndexerProcessorName = MediaProcessorNames.AzureMediaIndexer;
 string azureMediaHyperlapseProcessorName = MediaProcessorNames.AzureMediaHyperlapse;
+string mediaEncoderStandardProcessorName = MediaProcessorNames.MediaEncoderStandard;
 string mediaEncoderPremiumWorkflowProcessorName = MediaProcessorNames.MediaEncoderPremiumWorkflow;
 
 // Get the latest version of a media processor by its name using a single extension method.
 IMediaProcessor azureMediaEncoderProcessor = context.MediaProcessors.GetLatestMediaProcessorByName(azureMediaEncoderProcessorName);
 IMediaProcessor azureMediaIndexerProcessor = context.MediaProcessors.GetLatestMediaProcessorByName(azureMediaIndexerProcessorName);
 IMediaProcessor azureMediaHyperlapseProcessor = context.MediaProcessors.GetLatestMediaProcessorByName(azureMediaHyperlapseProcessorName);
+IMediaProcessor mediaEncoderStandardProcessor = context.MediaProcessors.GetLatestMediaProcessorByName(mediaEncoderStandardProcessorName);
 IMediaProcessor mediaEncoderPremiumWorkflowProcessor = context.MediaProcessors.GetLatestMediaProcessorByName(mediaEncoderPremiumWorkflowProcessorName);
 ```
 


### PR DESCRIPTION
- Updated references to use Azure Media Services SDK 3.5.1.0
- Added 'Media Encoder Standard' processor name
- Marked 'Windows Azure Media Encoder' processor name as deprecated (obsolete)
- Updated Readme