### PR TITLE
.NET SDK upgrade and new features

### DIFF
--- a/.nuget/windowsazure.mediaservices.extensions.nuspec
+++ b/.nuget/windowsazure.mediaservices.extensions.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>windowsazure.mediaservices.extensions</id>
-    <version>3.5.2.0</version>
+    <version>3.7.0.1</version>
     <title>Windows Azure Media Services .NET SDK Extensions</title>
     <authors>Microsoft Corporation</authors>
     <owners>Microsoft Corporation</owners>
@@ -22,7 +22,7 @@
       <dependency id="TransientFaultHandling.Core" version="5.1.1209.1" />
       <dependency id="WindowsAzure.Storage" version="4.3.0.0" />
       <dependency id="Newtonsoft.Json" version="6.0.8.0" />
-      <dependency id="windowsazure.mediaservices" version="3.5.2.0" />
+      <dependency id="windowsazure.mediaservices" version="3.7.0.1" />
     </dependencies>
   </metadata>
 </package>

--- a/MediaServices.Client.Extensions.Tests/AssetBaseCollectionExtensionsFixture.cs
+++ b/MediaServices.Client.Extensions.Tests/AssetBaseCollectionExtensionsFixture.cs
@@ -334,7 +334,6 @@ namespace MediaServices.Client.Extensions.Tests
         [DeploymentItem(@"Media\dummy.ism", "Media")]
         public void ShouldCreateAssetFromFolderWithRandomAccountSelectionStrategy()
         {
-
             RandomAccountSelectionStrategy strategy = RandomAccountSelectionStrategy.FromAccounts(context);
             var folderName = "Media";
             this.asset = this.context.Assets.CreateFromFolder(folderName, strategy, AssetCreationOptions.None, null);

--- a/MediaServices.Client.Extensions.Tests/CapacityBasedAccountSelectionStrategyFixture.cs
+++ b/MediaServices.Client.Extensions.Tests/CapacityBasedAccountSelectionStrategyFixture.cs
@@ -14,15 +14,15 @@
 // limitations under the License.
 // </license>
 
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Microsoft.WindowsAzure.MediaServices.Client;
-using MediaServices.Client.Extensions.Tests.Mocks;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-
 namespace MediaServices.Client.Extensions.Tests
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using MediaServices.Client.Extensions.Tests.Mocks;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Microsoft.WindowsAzure.MediaServices.Client;
+
     [TestClass]
     public class CapacityBasedAccountSelectionStrategyFixture
     {
@@ -73,7 +73,7 @@ namespace MediaServices.Client.Extensions.Tests
             List<IStorageAccount> storageAccountList = new List<IStorageAccount>();
 
             for (int i = 0; i < accountNames.Length; i++)
-            {            
+            {
                 IStorageAccount account = GetStorageAccount(accountNames[i], bytesUsedValues[i]);
                 storageAccountList.Add(account);
             }
@@ -124,7 +124,7 @@ namespace MediaServices.Client.Extensions.Tests
         public void CapacityBasedShouldThrowIfAccountNamesCannotBeFound()
         {
             List<IStorageAccount> storageAccountList = GetStorageAccountList(_fourStorageAccountNameArray, _evenBytesUsedValues);
-            
+
             MediaContextBase context = GetMediaContextBase(storageAccountList);
 
             CapacityBasedAccountSelectionStrategy strategy = new CapacityBasedAccountSelectionStrategy(context);
@@ -150,7 +150,7 @@ namespace MediaServices.Client.Extensions.Tests
             List<IStorageAccount> storageAccountList = GetStorageAccountList(_fourStorageAccountNameArray, _oneZeroBytesUsedValues);
 
             MediaContextBase context = GetMediaContextBase(storageAccountList);
-            CapacityBasedAccountSelectionStrategy strategy = CapacityBasedAccountSelectionStrategy.FromAccounts(context, maximumStorageAccountCapacity:oneGB);
+            CapacityBasedAccountSelectionStrategy strategy = CapacityBasedAccountSelectionStrategy.FromAccounts(context, maximumStorageAccountCapacity: oneGB);
 
             string accountNameToUse = strategy.SelectAccountForAsset();
 
@@ -168,7 +168,7 @@ namespace MediaServices.Client.Extensions.Tests
 
             MediaContextBase context = GetMediaContextBase(storageAccountList);
 
-            CapacityBasedAccountSelectionStrategy strategy = CapacityBasedAccountSelectionStrategy.FromAccounts(context, includeAccountsWithNoCapacityData:true, maximumStorageAccountCapacity: oneGB);
+            CapacityBasedAccountSelectionStrategy strategy = CapacityBasedAccountSelectionStrategy.FromAccounts(context, includeAccountsWithNoCapacityData: true, maximumStorageAccountCapacity: oneGB);
 
             strategy.Random = new RandomNumberGeneratorMock(_valuesForRandomNumberGeneratorToReturnEven);
 
@@ -205,7 +205,7 @@ namespace MediaServices.Client.Extensions.Tests
             // we will always pick the two middle accounts.
             storageAccountList = GetStorageAccountList(_fourStorageAccountNameArray, _skewedBytesUsedValues);
             context = GetMediaContextBase(storageAccountList);
-            strategy = CapacityBasedAccountSelectionStrategy.FromAccounts(context, maximumStorageAccountCapacity:oneGB);
+            strategy = CapacityBasedAccountSelectionStrategy.FromAccounts(context, maximumStorageAccountCapacity: oneGB);
 
             strategy.Random = new RandomNumberGeneratorMock(_valuesForRandomNumberGeneratorToReturnEven);
 
@@ -243,7 +243,7 @@ namespace MediaServices.Client.Extensions.Tests
             List<IStorageAccount> storageAccountList = GetStorageAccountList(_fourStorageAccountNameArray, _evenBytesUsedValues);
 
             MediaContextBase context = GetMediaContextBase(storageAccountList);
-            CapacityBasedAccountSelectionStrategy strategy = CapacityBasedAccountSelectionStrategy.FromAccounts(context, maximumStorageAccountCapacity:oneGB);
+            CapacityBasedAccountSelectionStrategy strategy = CapacityBasedAccountSelectionStrategy.FromAccounts(context, maximumStorageAccountCapacity: oneGB);
 
             VerifyStrategyEntriesMatchExpectations(storageAccountList, strategy, oneGB, false);
 
@@ -272,7 +272,7 @@ namespace MediaServices.Client.Extensions.Tests
 
             // Create the CapacityBasedAccountSelectionStrategy
             MediaContextBase context = GetMediaContextBase(storageAccountList);
-            CapacityBasedAccountSelectionStrategy strategy = CapacityBasedAccountSelectionStrategy.FromAccounts(context, maximumStorageAccountCapacity: oneGB, storageAccountNames:filterArray);
+            CapacityBasedAccountSelectionStrategy strategy = CapacityBasedAccountSelectionStrategy.FromAccounts(context, maximumStorageAccountCapacity: oneGB, storageAccountNames: filterArray);
 
             // Now ensure that the internal list only has the expected number of entries.
             IList<CapacityBasedAccountSelectionStrategyListEntry> accountListFromStrategy = strategy.GetStorageAccounts();

--- a/MediaServices.Client.Extensions.Tests/IAssetExtensionsFixture.cs
+++ b/MediaServices.Client.Extensions.Tests/IAssetExtensionsFixture.cs
@@ -183,6 +183,7 @@ namespace MediaServices.Client.Extensions.Tests
                 af =>
                     !af.Name.EndsWith(IAssetExtensions.MetadataFileSuffix, StringComparison.OrdinalIgnoreCase)
                     && !af.Name.EndsWith(ILocatorExtensions.ManifestFileExtension, StringComparison.OrdinalIgnoreCase)
+                    && !af.Name.EndsWith(ILocatorExtensions.ClientManifestFileExtension, StringComparison.OrdinalIgnoreCase)
                     && !af.Name.EndsWith(IAssetExtensions.InputMetadataFileSuffix, StringComparison.OrdinalIgnoreCase)
                     )
                 .OrderBy(af => af.Name)
@@ -265,6 +266,7 @@ namespace MediaServices.Client.Extensions.Tests
                 af =>
                     !af.Name.EndsWith(IAssetExtensions.MetadataFileSuffix, StringComparison.OrdinalIgnoreCase)
                     && !af.Name.EndsWith(ILocatorExtensions.ManifestFileExtension, StringComparison.OrdinalIgnoreCase)
+                    && !af.Name.EndsWith(ILocatorExtensions.ClientManifestFileExtension, StringComparison.OrdinalIgnoreCase)
                     && !af.Name.EndsWith(IAssetExtensions.InputMetadataFileSuffix, StringComparison.OrdinalIgnoreCase)
                     )
                 .OrderBy(af => af.Name)

--- a/MediaServices.Client.Extensions.Tests/IAssetExtensionsFixture.cs
+++ b/MediaServices.Client.Extensions.Tests/IAssetExtensionsFixture.cs
@@ -213,13 +213,13 @@ namespace MediaServices.Client.Extensions.Tests
                 Assert.IsNotNull(assetMetadataArray[i].AudioTracks);
                 Assert.AreEqual(1, assetMetadataArray[i].AudioTracks.Count());
                 Assert.IsNotNull(assetMetadataArray[i].AudioTracks.ElementAt(0));
-                Assert.IsNull(assetMetadataArray[i].AudioTracks.ElementAt(0).EncoderVersion);
+                ////Assert.IsNull(assetMetadataArray[i].AudioTracks.ElementAt(0).EncoderVersion);
                 Assert.AreEqual(2, assetMetadataArray[i].AudioTracks.ElementAt(0).Id);
                 Assert.AreEqual("aac", assetMetadataArray[i].AudioTracks.ElementAt(0).Codec, true);
                 Assert.AreEqual(2, assetMetadataArray[i].AudioTracks.ElementAt(0).Channels);
                 Assert.AreEqual(48000, assetMetadataArray[i].AudioTracks.ElementAt(0).SamplingRate);
                 Assert.AreEqual(128, assetMetadataArray[i].AudioTracks.ElementAt(0).Bitrate);
-                Assert.AreEqual(0, assetMetadataArray[i].AudioTracks.ElementAt(0).BitsPerSample);
+                ////Assert.AreEqual(0, assetMetadataArray[i].AudioTracks.ElementAt(0).BitsPerSample);
                 Assert.AreEqual("und", assetMetadataArray[i].AudioTracks.ElementAt(0).Language, true);
             }
         }
@@ -284,13 +284,13 @@ namespace MediaServices.Client.Extensions.Tests
                 Assert.IsNotNull(assetMetadataArray[i].AudioTracks);
                 Assert.AreEqual(1, assetMetadataArray[i].AudioTracks.Count());
                 Assert.IsNotNull(assetMetadataArray[i].AudioTracks.ElementAt(0));
-                Assert.IsNull(assetMetadataArray[i].AudioTracks.ElementAt(0).EncoderVersion);
+                ////Assert.IsNull(assetMetadataArray[i].AudioTracks.ElementAt(0).EncoderVersion);
                 Assert.AreEqual(2, assetMetadataArray[i].AudioTracks.ElementAt(0).Id);
                 Assert.AreEqual("aac", assetMetadataArray[i].AudioTracks.ElementAt(0).Codec, true);
                 Assert.AreEqual(2, assetMetadataArray[i].AudioTracks.ElementAt(0).Channels);
                 Assert.AreEqual(48000, assetMetadataArray[i].AudioTracks.ElementAt(0).SamplingRate);
                 Assert.AreEqual(128, assetMetadataArray[i].AudioTracks.ElementAt(0).Bitrate);
-                Assert.AreEqual(0, assetMetadataArray[i].AudioTracks.ElementAt(0).BitsPerSample);
+                ////Assert.AreEqual(0, assetMetadataArray[i].AudioTracks.ElementAt(0).BitsPerSample);
                 Assert.AreEqual("und", assetMetadataArray[i].AudioTracks.ElementAt(0).Language, true);
             }
         }

--- a/MediaServices.Client.Extensions.Tests/IAssetExtensionsFixture.cs
+++ b/MediaServices.Client.Extensions.Tests/IAssetExtensionsFixture.cs
@@ -29,9 +29,8 @@ namespace MediaServices.Client.Extensions.Tests
     [TestClass]
     public class IAssetExtensionsFixture
     {
-        private static readonly int[] TargetBitrates = { 1000, 1500, 2250, 3400, 400, 650 };
-        private static readonly int[] Widths = { 480, 720, 720, 960, 240, 480 };
-        private static readonly int[] Heights = { 360, 540, 540, 720, 180, 360 };
+        private static readonly int[] Widths = { 240, 480, 480, 720, 720, 960 };
+        private static readonly int[] Heights = { 180, 360, 360, 540, 540, 720 };
 
         private CloudMediaContext context;
         private IAsset asset;
@@ -157,12 +156,11 @@ namespace MediaServices.Client.Extensions.Tests
         [DeploymentItem(@"Media\smallwmv1.wmv")]
         public void ShouldGetAssetMetadata()
         {
-            var source = "smallwmv1.wmv";
-            this.asset = this.context.Assets.CreateFromFile(source, AssetCreationOptions.None);
+            this.asset = this.context.Assets.CreateFromFile("smallwmv1.wmv", AssetCreationOptions.None);
 
             var job = this.context.Jobs.CreateWithSingleTask(
-                MediaProcessorNames.AzureMediaEncoder,
-                MediaEncoderTaskPresetStrings.H264AdaptiveBitrateMP4Set720p,
+                MediaProcessorNames.MediaEncoderStandard,
+                MediaEncoderStandardTaskPresetStrings.H264MultipleBitrate720p,
                 this.asset,
                 "Output Asset Name",
                 AssetCreationOptions.None);
@@ -179,13 +177,10 @@ namespace MediaServices.Client.Extensions.Tests
             var assetFilesArray = this.outputAsset
                 .AssetFiles
                 .ToArray()
-                .Where(
-                af =>
-                    !af.Name.EndsWith(IAssetExtensions.MetadataFileSuffix, StringComparison.OrdinalIgnoreCase)
+                .Where(af => !af.Name.EndsWith(IAssetExtensions.MetadataFileSuffix, StringComparison.OrdinalIgnoreCase)
                     && !af.Name.EndsWith(ILocatorExtensions.ManifestFileExtension, StringComparison.OrdinalIgnoreCase)
                     && !af.Name.EndsWith(ILocatorExtensions.ClientManifestFileExtension, StringComparison.OrdinalIgnoreCase)
-                    && !af.Name.EndsWith(IAssetExtensions.InputMetadataFileSuffix, StringComparison.OrdinalIgnoreCase)
-                    )
+                    && !af.Name.EndsWith(IAssetExtensions.InputMetadataFileSuffix, StringComparison.OrdinalIgnoreCase))
                 .OrderBy(af => af.Name)
                 .ToArray();
 
@@ -197,42 +192,35 @@ namespace MediaServices.Client.Extensions.Tests
             {
                 Assert.AreEqual(assetFilesArray[i].Name, assetMetadataArray[i].Name);
                 Assert.AreEqual(assetFilesArray[i].ContentFileSize, assetMetadataArray[i].Size);
-                Assert.AreEqual(TimeSpan.FromSeconds(5.119), assetMetadataArray[i].Duration);
+                Assert.AreEqual(TimeSpan.FromSeconds(5.206), assetMetadataArray[i].Duration);
 
                 Assert.IsNotNull(assetMetadataArray[i].Sources);
                 Assert.AreEqual(1, assetMetadataArray[i].Sources.Count());
                 Assert.IsNotNull(assetMetadataArray[i].Sources.ElementAt(0));
-                Assert.AreEqual(source, assetMetadataArray[i].Sources.ElementAt(0).Name);
+                Assert.AreEqual(assetFilesArray[i].Name, assetMetadataArray[i].Sources.ElementAt(0).Name);
 
-                if (i >= 2)
-                {
-                    Assert.IsNotNull(assetMetadataArray[i].VideoTracks);
-                    Assert.AreEqual(1, assetMetadataArray[i].VideoTracks.Count());
-                    Assert.IsNotNull(assetMetadataArray[i].VideoTracks.ElementAt(0));
-                    Assert.AreEqual(0, assetMetadataArray[i].VideoTracks.ElementAt(0).Id);
-                    Assert.AreEqual("AVC1", assetMetadataArray[i].VideoTracks.ElementAt(0).FourCC);
-                    Assert.AreEqual(Widths[i - 2], assetMetadataArray[i].VideoTracks.ElementAt(0).Width);
-                    Assert.AreEqual(Heights[i - 2], assetMetadataArray[i].VideoTracks.ElementAt(0).Height);
-                    Assert.AreEqual(4, assetMetadataArray[i].VideoTracks.ElementAt(0).DisplayAspectRatioNumerator);
-                    Assert.AreEqual(3, assetMetadataArray[i].VideoTracks.ElementAt(0).DisplayAspectRatioDenominator);
-                    Assert.AreEqual(29.97, assetMetadataArray[i].VideoTracks.ElementAt(0).TargetFramerate);
-                    Assert.AreEqual(TargetBitrates[i - 2], assetMetadataArray[i].VideoTracks.ElementAt(0).TargetBitrate);
-                }
-                else
-                {
-                    Assert.IsNull(assetMetadataArray[i].VideoTracks);
-                }
+                Assert.IsNotNull(assetMetadataArray[i].VideoTracks);
+                Assert.AreEqual(1, assetMetadataArray[i].VideoTracks.Count());
+                Assert.IsNotNull(assetMetadataArray[i].VideoTracks.ElementAt(0));
+                Assert.AreEqual(1, assetMetadataArray[i].VideoTracks.ElementAt(0).Id);
+                Assert.AreEqual("avc1", assetMetadataArray[i].VideoTracks.ElementAt(0).FourCC, true);
+                Assert.AreEqual(Widths[i], assetMetadataArray[i].VideoTracks.ElementAt(0).Width);
+                Assert.AreEqual(Heights[i], assetMetadataArray[i].VideoTracks.ElementAt(0).Height);
+                Assert.AreEqual(4, assetMetadataArray[i].VideoTracks.ElementAt(0).DisplayAspectRatioNumerator);
+                Assert.AreEqual(3, assetMetadataArray[i].VideoTracks.ElementAt(0).DisplayAspectRatioDenominator);
+                ////Assert.AreEqual(29.971, assetMetadataArray[i].VideoTracks.ElementAt(0).TargetFramerate);
 
                 Assert.IsNotNull(assetMetadataArray[i].AudioTracks);
                 Assert.AreEqual(1, assetMetadataArray[i].AudioTracks.Count());
                 Assert.IsNotNull(assetMetadataArray[i].AudioTracks.ElementAt(0));
                 Assert.IsNull(assetMetadataArray[i].AudioTracks.ElementAt(0).EncoderVersion);
-                Assert.AreEqual(0, assetMetadataArray[i].AudioTracks.ElementAt(0).Id);
-                Assert.AreEqual("AacLc", assetMetadataArray[i].AudioTracks.ElementAt(0).Codec);
+                Assert.AreEqual(2, assetMetadataArray[i].AudioTracks.ElementAt(0).Id);
+                Assert.AreEqual("aac", assetMetadataArray[i].AudioTracks.ElementAt(0).Codec, true);
                 Assert.AreEqual(2, assetMetadataArray[i].AudioTracks.ElementAt(0).Channels);
-                Assert.AreEqual(44100, assetMetadataArray[i].AudioTracks.ElementAt(0).SamplingRate);
-                Assert.AreEqual(i == 0 ? 53 : 93, assetMetadataArray[i].AudioTracks.ElementAt(0).Bitrate);
-                Assert.AreEqual(16, assetMetadataArray[i].AudioTracks.ElementAt(0).BitsPerSample);
+                Assert.AreEqual(48000, assetMetadataArray[i].AudioTracks.ElementAt(0).SamplingRate);
+                Assert.AreEqual(128, assetMetadataArray[i].AudioTracks.ElementAt(0).Bitrate);
+                Assert.AreEqual(0, assetMetadataArray[i].AudioTracks.ElementAt(0).BitsPerSample);
+                Assert.AreEqual("und", assetMetadataArray[i].AudioTracks.ElementAt(0).Language, true);
             }
         }
 
@@ -240,12 +228,11 @@ namespace MediaServices.Client.Extensions.Tests
         [DeploymentItem(@"Media\smallwmv1.wmv")]
         public void ShouldGetAssetMetadataWithSpecificLocator()
         {
-            var source = "smallwmv1.wmv";
-            this.asset = this.context.Assets.CreateFromFile(source, AssetCreationOptions.None);
+            this.asset = this.context.Assets.CreateFromFile("smallwmv1.wmv", AssetCreationOptions.None);
 
             var job = this.context.Jobs.CreateWithSingleTask(
-                MediaProcessorNames.AzureMediaEncoder,
-                MediaEncoderTaskPresetStrings.H264AdaptiveBitrateMP4Set720p,
+                MediaProcessorNames.MediaEncoderStandard,
+                MediaEncoderStandardTaskPresetStrings.H264MultipleBitrate720p,
                 this.asset,
                 "Output Asset Name",
                 AssetCreationOptions.None);
@@ -262,13 +249,10 @@ namespace MediaServices.Client.Extensions.Tests
             var assetFilesArray = this.outputAsset
                 .AssetFiles
                 .ToArray()
-                .Where(
-                af =>
-                    !af.Name.EndsWith(IAssetExtensions.MetadataFileSuffix, StringComparison.OrdinalIgnoreCase)
+                .Where(af => !af.Name.EndsWith(IAssetExtensions.MetadataFileSuffix, StringComparison.OrdinalIgnoreCase)
                     && !af.Name.EndsWith(ILocatorExtensions.ManifestFileExtension, StringComparison.OrdinalIgnoreCase)
                     && !af.Name.EndsWith(ILocatorExtensions.ClientManifestFileExtension, StringComparison.OrdinalIgnoreCase)
-                    && !af.Name.EndsWith(IAssetExtensions.InputMetadataFileSuffix, StringComparison.OrdinalIgnoreCase)
-                    )
+                    && !af.Name.EndsWith(IAssetExtensions.InputMetadataFileSuffix, StringComparison.OrdinalIgnoreCase))
                 .OrderBy(af => af.Name)
                 .ToArray();
             var assetMetadataArray = assetMetadata.OrderBy(am => am.Name).ToArray();
@@ -279,42 +263,35 @@ namespace MediaServices.Client.Extensions.Tests
             {
                 Assert.AreEqual(assetFilesArray[i].Name, assetMetadataArray[i].Name);
                 Assert.AreEqual(assetFilesArray[i].ContentFileSize, assetMetadataArray[i].Size);
-                Assert.AreEqual(TimeSpan.FromSeconds(5.119), assetMetadataArray[i].Duration);
+                Assert.AreEqual(TimeSpan.FromSeconds(5.206), assetMetadataArray[i].Duration);
 
                 Assert.IsNotNull(assetMetadataArray[i].Sources);
                 Assert.AreEqual(1, assetMetadataArray[i].Sources.Count());
                 Assert.IsNotNull(assetMetadataArray[i].Sources.ElementAt(0));
-                Assert.AreEqual(source, assetMetadataArray[i].Sources.ElementAt(0).Name);
+                Assert.AreEqual(assetFilesArray[i].Name, assetMetadataArray[i].Sources.ElementAt(0).Name);
 
-                if (i >= 2)
-                {
-                    Assert.IsNotNull(assetMetadataArray[i].VideoTracks);
-                    Assert.AreEqual(1, assetMetadataArray[i].VideoTracks.Count());
-                    Assert.IsNotNull(assetMetadataArray[i].VideoTracks.ElementAt(0));
-                    Assert.AreEqual(0, assetMetadataArray[i].VideoTracks.ElementAt(0).Id);
-                    Assert.AreEqual("AVC1", assetMetadataArray[i].VideoTracks.ElementAt(0).FourCC);
-                    Assert.AreEqual(Widths[i - 2], assetMetadataArray[i].VideoTracks.ElementAt(0).Width);
-                    Assert.AreEqual(Heights[i - 2], assetMetadataArray[i].VideoTracks.ElementAt(0).Height);
-                    Assert.AreEqual(4, assetMetadataArray[i].VideoTracks.ElementAt(0).DisplayAspectRatioNumerator);
-                    Assert.AreEqual(3, assetMetadataArray[i].VideoTracks.ElementAt(0).DisplayAspectRatioDenominator);
-                    Assert.AreEqual(29.97, assetMetadataArray[i].VideoTracks.ElementAt(0).TargetFramerate);
-                    Assert.AreEqual(TargetBitrates[i - 2], assetMetadataArray[i].VideoTracks.ElementAt(0).TargetBitrate);
-                }
-                else
-                {
-                    Assert.IsNull(assetMetadataArray[i].VideoTracks);
-                }
+                Assert.IsNotNull(assetMetadataArray[i].VideoTracks);
+                Assert.AreEqual(1, assetMetadataArray[i].VideoTracks.Count());
+                Assert.IsNotNull(assetMetadataArray[i].VideoTracks.ElementAt(0));
+                Assert.AreEqual(1, assetMetadataArray[i].VideoTracks.ElementAt(0).Id);
+                Assert.AreEqual("avc1", assetMetadataArray[i].VideoTracks.ElementAt(0).FourCC, true);
+                Assert.AreEqual(Widths[i], assetMetadataArray[i].VideoTracks.ElementAt(0).Width);
+                Assert.AreEqual(Heights[i], assetMetadataArray[i].VideoTracks.ElementAt(0).Height);
+                Assert.AreEqual(4, assetMetadataArray[i].VideoTracks.ElementAt(0).DisplayAspectRatioNumerator);
+                Assert.AreEqual(3, assetMetadataArray[i].VideoTracks.ElementAt(0).DisplayAspectRatioDenominator);
+                ////Assert.AreEqual(29.971, assetMetadataArray[i].VideoTracks.ElementAt(0).TargetFramerate);
 
                 Assert.IsNotNull(assetMetadataArray[i].AudioTracks);
                 Assert.AreEqual(1, assetMetadataArray[i].AudioTracks.Count());
                 Assert.IsNotNull(assetMetadataArray[i].AudioTracks.ElementAt(0));
                 Assert.IsNull(assetMetadataArray[i].AudioTracks.ElementAt(0).EncoderVersion);
-                Assert.AreEqual(0, assetMetadataArray[i].AudioTracks.ElementAt(0).Id);
-                Assert.AreEqual("AacLc", assetMetadataArray[i].AudioTracks.ElementAt(0).Codec);
+                Assert.AreEqual(2, assetMetadataArray[i].AudioTracks.ElementAt(0).Id);
+                Assert.AreEqual("aac", assetMetadataArray[i].AudioTracks.ElementAt(0).Codec, true);
                 Assert.AreEqual(2, assetMetadataArray[i].AudioTracks.ElementAt(0).Channels);
-                Assert.AreEqual(44100, assetMetadataArray[i].AudioTracks.ElementAt(0).SamplingRate);
-                Assert.AreEqual(i == 0 ? 53 : 93, assetMetadataArray[i].AudioTracks.ElementAt(0).Bitrate);
-                Assert.AreEqual(16, assetMetadataArray[i].AudioTracks.ElementAt(0).BitsPerSample);
+                Assert.AreEqual(48000, assetMetadataArray[i].AudioTracks.ElementAt(0).SamplingRate);
+                Assert.AreEqual(128, assetMetadataArray[i].AudioTracks.ElementAt(0).Bitrate);
+                Assert.AreEqual(0, assetMetadataArray[i].AudioTracks.ElementAt(0).BitsPerSample);
+                Assert.AreEqual("und", assetMetadataArray[i].AudioTracks.ElementAt(0).Language, true);
             }
         }
 

--- a/MediaServices.Client.Extensions.Tests/IAssetFileExtensionsFixture.cs
+++ b/MediaServices.Client.Extensions.Tests/IAssetFileExtensionsFixture.cs
@@ -200,13 +200,13 @@ namespace MediaServices.Client.Extensions.Tests
             Assert.IsNotNull(assetFileMetadata.AudioTracks);
             Assert.AreEqual(1, assetFileMetadata.AudioTracks.Count());
             Assert.IsNotNull(assetFileMetadata.AudioTracks.ElementAt(0));
-            Assert.IsNull(assetFileMetadata.AudioTracks.ElementAt(0).EncoderVersion);
+            ////Assert.IsNull(assetFileMetadata.AudioTracks.ElementAt(0).EncoderVersion);
             Assert.AreEqual(2, assetFileMetadata.AudioTracks.ElementAt(0).Id);
             Assert.AreEqual("aac", assetFileMetadata.AudioTracks.ElementAt(0).Codec, true);
             Assert.AreEqual(2, assetFileMetadata.AudioTracks.ElementAt(0).Channels);
             Assert.AreEqual(48000, assetFileMetadata.AudioTracks.ElementAt(0).SamplingRate);
             Assert.AreEqual(128, assetFileMetadata.AudioTracks.ElementAt(0).Bitrate);
-            Assert.AreEqual(0, assetFileMetadata.AudioTracks.ElementAt(0).BitsPerSample);
+            ////Assert.AreEqual(0, assetFileMetadata.AudioTracks.ElementAt(0).BitsPerSample);
             Assert.AreEqual("und", assetFileMetadata.AudioTracks.ElementAt(0).Language, true);
         }
 

--- a/MediaServices.Client.Extensions.Tests/IAssetFileExtensionsFixture.cs
+++ b/MediaServices.Client.Extensions.Tests/IAssetFileExtensionsFixture.cs
@@ -145,12 +145,11 @@ namespace MediaServices.Client.Extensions.Tests
         [DeploymentItem(@"Media\smallwmv1.wmv")]
         public void ShouldGetAssetFileMetadata()
         {
-            var source = "smallwmv1.wmv";
-            this.asset = this.context.Assets.CreateFromFile(source, AssetCreationOptions.None);
+            this.asset = this.context.Assets.CreateFromFile("smallwmv1.wmv", AssetCreationOptions.None);
 
             var job = this.context.Jobs.CreateWithSingleTask(
-                MediaProcessorNames.AzureMediaEncoder,
-                MediaEncoderTaskPresetStrings.H264AdaptiveBitrateMP4Set720p,
+                MediaProcessorNames.MediaEncoderStandard,
+                MediaEncoderStandardTaskPresetStrings.H264MultipleBitrate720p,
                 this.asset,
                 "Output Asset Name",
                 AssetCreationOptions.None);
@@ -160,10 +159,11 @@ namespace MediaServices.Client.Extensions.Tests
 
             this.outputAsset = job.OutputMediaAssets[0];
 
+            var source = "smallwmv1_960x720_3400.mp4";
             var assetFile = this.outputAsset
                 .AssetFiles
                 .ToList()
-                .First(af => af.Name.Equals("smallwmv1_H264_3400kbps_AAC_und_ch2_96kbps.mp4", StringComparison.OrdinalIgnoreCase));
+                .First(af => af.Name.Equals(source, StringComparison.OrdinalIgnoreCase));
 
             var sasLocator = this.context.Locators.Create(
                 LocatorType.Sas,
@@ -176,7 +176,7 @@ namespace MediaServices.Client.Extensions.Tests
             Assert.IsNotNull(assetFileMetadata);
             Assert.AreEqual(assetFile.Name, assetFileMetadata.Name);
             Assert.AreEqual(assetFile.ContentFileSize, assetFileMetadata.Size);
-            Assert.AreEqual(TimeSpan.FromSeconds(5.119), assetFileMetadata.Duration);
+            Assert.AreEqual(TimeSpan.FromSeconds(5.206), assetFileMetadata.Duration);
 
             Assert.IsNotNull(assetFileMetadata.Sources);
             Assert.AreEqual(1, assetFileMetadata.Sources.Count());
@@ -186,27 +186,28 @@ namespace MediaServices.Client.Extensions.Tests
             Assert.IsNotNull(assetFileMetadata.VideoTracks);
             Assert.AreEqual(1, assetFileMetadata.VideoTracks.Count());
             Assert.IsNotNull(assetFileMetadata.VideoTracks.ElementAt(0));
-            Assert.AreEqual(0, assetFileMetadata.VideoTracks.ElementAt(0).Id);
-            Assert.AreEqual("AVC1", assetFileMetadata.VideoTracks.ElementAt(0).FourCC);
+            Assert.AreEqual(1, assetFileMetadata.VideoTracks.ElementAt(0).Id);
+            Assert.AreEqual("avc1", assetFileMetadata.VideoTracks.ElementAt(0).FourCC, true);
             Assert.AreEqual(960, assetFileMetadata.VideoTracks.ElementAt(0).Width);
             Assert.AreEqual(720, assetFileMetadata.VideoTracks.ElementAt(0).Height);
             Assert.AreEqual(4, assetFileMetadata.VideoTracks.ElementAt(0).DisplayAspectRatioNumerator);
             Assert.AreEqual(3, assetFileMetadata.VideoTracks.ElementAt(0).DisplayAspectRatioDenominator);
-            ////Assert.AreEqual(29.974, assetFileMetadata.VideoTracks.ElementAt(0).Framerate);
-            Assert.AreEqual(29.97, assetFileMetadata.VideoTracks.ElementAt(0).TargetFramerate);
+            ////Assert.AreEqual(29.971, assetFileMetadata.VideoTracks.ElementAt(0).Framerate);
+            ////Assert.AreEqual(29.97, assetFileMetadata.VideoTracks.ElementAt(0).TargetFramerate);
             ////Assert.AreEqual(3804, assetFileMetadata.VideoTracks.ElementAt(0).Bitrate);
-            Assert.AreEqual(3400, assetFileMetadata.VideoTracks.ElementAt(0).TargetBitrate);
+            ////Assert.AreEqual(3400, assetFileMetadata.VideoTracks.ElementAt(0).TargetBitrate);
 
             Assert.IsNotNull(assetFileMetadata.AudioTracks);
             Assert.AreEqual(1, assetFileMetadata.AudioTracks.Count());
             Assert.IsNotNull(assetFileMetadata.AudioTracks.ElementAt(0));
             Assert.IsNull(assetFileMetadata.AudioTracks.ElementAt(0).EncoderVersion);
-            Assert.AreEqual(0, assetFileMetadata.AudioTracks.ElementAt(0).Id);
-            Assert.AreEqual("AacLc", assetFileMetadata.AudioTracks.ElementAt(0).Codec);
+            Assert.AreEqual(2, assetFileMetadata.AudioTracks.ElementAt(0).Id);
+            Assert.AreEqual("aac", assetFileMetadata.AudioTracks.ElementAt(0).Codec, true);
             Assert.AreEqual(2, assetFileMetadata.AudioTracks.ElementAt(0).Channels);
-            Assert.AreEqual(44100, assetFileMetadata.AudioTracks.ElementAt(0).SamplingRate);
-            Assert.AreEqual(93, assetFileMetadata.AudioTracks.ElementAt(0).Bitrate);
-            Assert.AreEqual(16, assetFileMetadata.AudioTracks.ElementAt(0).BitsPerSample);
+            Assert.AreEqual(48000, assetFileMetadata.AudioTracks.ElementAt(0).SamplingRate);
+            Assert.AreEqual(128, assetFileMetadata.AudioTracks.ElementAt(0).Bitrate);
+            Assert.AreEqual(0, assetFileMetadata.AudioTracks.ElementAt(0).BitsPerSample);
+            Assert.AreEqual("und", assetFileMetadata.AudioTracks.ElementAt(0).Language, true);
         }
 
         [TestMethod]

--- a/MediaServices.Client.Extensions.Tests/IJobExtensionsFixture.cs
+++ b/MediaServices.Client.Extensions.Tests/IJobExtensionsFixture.cs
@@ -124,8 +124,8 @@ namespace MediaServices.Client.Extensions.Tests
         [ExpectedException(typeof(ArgumentException))]
         public void ShouldThrowStartExecutionProgressTaskIfJobDoesNotHaveValidId()
         {
-            var mediaProcessorName = MediaProcessorNames.AzureMediaEncoder;
-            var taskConfiguration = MediaEncoderTaskPresetStrings.H264SmoothStreaming720p;
+            var mediaProcessorName = MediaProcessorNames.MediaEncoderStandard;
+            var taskConfiguration = MediaEncoderStandardTaskPresetStrings.H264SingleBitrate720p;
             var outputAssetName = "Output Asset Name";
             var outputAssetOptions = AssetCreationOptions.None;
             this.asset = this.context.Assets.Create("TestAsset", AssetCreationOptions.None);
@@ -139,8 +139,8 @@ namespace MediaServices.Client.Extensions.Tests
         [DeploymentItem(@"Media\smallwmv1.wmv")]
         public void ShouldStartExecutionProgressTaskAndInvokeCallbackWhenStateOrOverallProgressChange()
         {
-            var mediaProcessorName = MediaProcessorNames.AzureMediaEncoder;
-            var taskConfiguration = MediaEncoderTaskPresetStrings.H264SmoothStreaming720p;
+            var mediaProcessorName = MediaProcessorNames.MediaEncoderStandard;
+            var taskConfiguration = MediaEncoderStandardTaskPresetStrings.H264SingleBitrate720p;
             var outputAssetName = "Output Asset Name";
             var outputAssetOptions = AssetCreationOptions.None;
             this.asset = this.context.Assets.CreateFromFile("smallwmv1.wmv", AssetCreationOptions.None);
@@ -184,8 +184,8 @@ namespace MediaServices.Client.Extensions.Tests
         [DeploymentItem(@"Media\smallwmv1.wmv")]
         public void ShouldStartExecutionProgressTaskWhenExecutionProgressChangedCallbackIsNull()
         {
-            var mediaProcessorName = MediaProcessorNames.AzureMediaEncoder;
-            var taskConfiguration = MediaEncoderTaskPresetStrings.H264SmoothStreaming720p;
+            var mediaProcessorName = MediaProcessorNames.MediaEncoderStandard;
+            var taskConfiguration = MediaEncoderStandardTaskPresetStrings.H264SingleBitrate720p;
             var outputAssetName = "Output Asset Name";
             var outputAssetOptions = AssetCreationOptions.None;
             this.asset = this.context.Assets.CreateFromFile("smallwmv1.wmv", AssetCreationOptions.None);

--- a/MediaServices.Client.Extensions.Tests/JobBaseCollectionExtensionsFixture.cs
+++ b/MediaServices.Client.Extensions.Tests/JobBaseCollectionExtensionsFixture.cs
@@ -31,8 +31,8 @@ namespace MediaServices.Client.Extensions.Tests
         [ExpectedException(typeof(ArgumentNullException))]
         public void ShouldThrowCreateWithSingleTaskIfJobCollectiontIsNull()
         {
-            var mediaProcessorName = MediaProcessorNames.AzureMediaEncoder;
-            var taskConfiguration = MediaEncoderTaskPresetStrings.H264SmoothStreaming720p;
+            var mediaProcessorName = MediaProcessorNames.MediaEncoderStandard;
+            var taskConfiguration = MediaEncoderStandardTaskPresetStrings.H264SingleBitrate720p;
             var outputAssetName = "Output Asset Name";
             var outputAssetOptions = AssetCreationOptions.None;
             this.asset = this.context.Assets.Create("empty", AssetCreationOptions.None);
@@ -45,8 +45,8 @@ namespace MediaServices.Client.Extensions.Tests
         [ExpectedException(typeof(ArgumentNullException))]
         public void ShouldThrowCreateWithSingleTaskIfInputAssetIsNull()
         {
-            var mediaProcessorName = MediaProcessorNames.AzureMediaEncoder;
-            var taskConfiguration = MediaEncoderTaskPresetStrings.H264SmoothStreaming720p;
+            var mediaProcessorName = MediaProcessorNames.MediaEncoderStandard;
+            var taskConfiguration = MediaEncoderStandardTaskPresetStrings.H264SingleBitrate720p;
             var outputAssetName = "Output Asset Name";
             var outputAssetOptions = AssetCreationOptions.None;
             IAsset inputAsset = null;
@@ -58,12 +58,12 @@ namespace MediaServices.Client.Extensions.Tests
         [ExpectedException(typeof(ArgumentNullException))]
         public void ShouldThrowCreateWithSingleTaskIfStrategyIsNull()
         {
-            var mediaProcessorName = MediaProcessorNames.AzureMediaEncoder;
-            var taskConfiguration = MediaEncoderTaskPresetStrings.H264SmoothStreaming720p;
+            var mediaProcessorName = MediaProcessorNames.MediaEncoderStandard;
+            var taskConfiguration = MediaEncoderStandardTaskPresetStrings.H264SingleBitrate720p;
             var outputAssetName = "Output Asset Name";
             var outputAssetOptions = AssetCreationOptions.None;
             IAccountSelectionStrategy strategy = null;
-            
+
             this.asset = this.context.Assets.CreateFromFile("smallwmv1.wmv", AssetCreationOptions.None);
 
             this.context.Jobs.CreateWithSingleTask(mediaProcessorName, taskConfiguration, this.asset, strategy, outputAssetName, outputAssetOptions);
@@ -74,7 +74,7 @@ namespace MediaServices.Client.Extensions.Tests
         public void ShouldThrowCreateWithSingleTaskIfMediaProcessorNameIsUnknown()
         {
             var mediaProcessorName = "Unknown Media Processor";
-            var taskConfiguration = MediaEncoderTaskPresetStrings.H264SmoothStreaming720p;
+            var taskConfiguration = MediaEncoderStandardTaskPresetStrings.H264SingleBitrate720p;
             var outputAssetName = "Output Asset Name";
             var outputAssetOptions = AssetCreationOptions.None;
             this.asset = this.context.Assets.Create("empty", AssetCreationOptions.None);
@@ -86,8 +86,8 @@ namespace MediaServices.Client.Extensions.Tests
         [DeploymentItem(@"Media\smallwmv1.wmv")]
         public void ShouldCreateWithSingleTask()
         {
-            var mediaProcessorName = MediaProcessorNames.AzureMediaEncoder;
-            var taskConfiguration = MediaEncoderTaskPresetStrings.H264SmoothStreaming720p;
+            var mediaProcessorName = MediaProcessorNames.MediaEncoderStandard;
+            var taskConfiguration = MediaEncoderStandardTaskPresetStrings.H264SingleBitrate720p;
             var outputAssetName = "Output Asset Name";
             var outputAssetOptions = AssetCreationOptions.None;
             this.asset = this.context.Assets.CreateFromFile("smallwmv1.wmv", AssetCreationOptions.None);

--- a/MediaServices.Client.Extensions.Tests/MediaProcessorBaseCollectionExtensionsFixture.cs
+++ b/MediaServices.Client.Extensions.Tests/MediaProcessorBaseCollectionExtensionsFixture.cs
@@ -16,7 +16,6 @@
 namespace MediaServices.Client.Extensions.Tests
 {
     using System;
-    using System.Configuration;
     using System.Linq;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Microsoft.WindowsAzure.MediaServices.Client;
@@ -32,7 +31,7 @@ namespace MediaServices.Client.Extensions.Tests
         {
             MediaProcessorBaseCollection nullMediaProcessorCollection = null;
 
-            nullMediaProcessorCollection.GetLatestMediaProcessorByName(MediaProcessorNames.AzureMediaEncoder);
+            nullMediaProcessorCollection.GetLatestMediaProcessorByName(MediaProcessorNames.MediaEncoderStandard);
         }
 
         [TestMethod]
@@ -47,12 +46,12 @@ namespace MediaServices.Client.Extensions.Tests
         [TestMethod]
         public void ShouldGetLatestMediaProcessorByName()
         {
-            var mediaProcessor = this.context.MediaProcessors.GetLatestMediaProcessorByName(MediaProcessorNames.AzureMediaEncoder);
+            var mediaProcessor = this.context.MediaProcessors.GetLatestMediaProcessorByName(MediaProcessorNames.MediaEncoderStandard);
 
             Assert.IsNotNull(mediaProcessor);
 
             var expectedMediaProcessor = this.context.MediaProcessors
-                .Where(mp => mp.Name == MediaProcessorNames.AzureMediaEncoder)
+                .Where(mp => mp.Name == MediaProcessorNames.MediaEncoderStandard)
                 .ToList()
                 .Select(mp => new { mp.Id, mp.Name, Version = new Version(mp.Version) })
                 .OrderBy(mp => mp.Version)

--- a/MediaServices.Client.Extensions.Tests/MediaServices.Client.Extensions.Tests.csproj
+++ b/MediaServices.Client.Extensions.Tests/MediaServices.Client.Extensions.Tests.csproj
@@ -55,17 +55,17 @@
       <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.3.1.0\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.MediaServices.Client, Version=3.5.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\windowsazure.mediaservices.3.5.2.0\lib\net45\Microsoft.WindowsAzure.MediaServices.Client.dll</HintPath>
+    <Reference Include="Microsoft.WindowsAzure.MediaServices.Client, Version=3.7.0.1, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\windowsazure.mediaservices.3.7.0.1\lib\net45\Microsoft.WindowsAzure.MediaServices.Client.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.MediaServices.Client.Common.BlobTransfer, Version=3.5.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\windowsazure.mediaservices.3.5.2.0\lib\net45\Microsoft.WindowsAzure.MediaServices.Client.Common.BlobTransfer.dll</HintPath>
+    <Reference Include="Microsoft.WindowsAzure.MediaServices.Client.Common.BlobTransfer, Version=3.7.0.1, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\windowsazure.mediaservices.3.7.0.1\lib\net45\Microsoft.WindowsAzure.MediaServices.Client.Common.BlobTransfer.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.MediaServices.Client.Common.FileEncryption, Version=3.5.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\windowsazure.mediaservices.3.5.2.0\lib\net45\Microsoft.WindowsAzure.MediaServices.Client.Common.FileEncryption.dll</HintPath>
+    <Reference Include="Microsoft.WindowsAzure.MediaServices.Client.Common.FileEncryption, Version=3.7.0.1, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\windowsazure.mediaservices.3.7.0.1\lib\net45\Microsoft.WindowsAzure.MediaServices.Client.Common.FileEncryption.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Storage, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/MediaServices.Client.Extensions.Tests/MediaServicesExceptionParserFixture.cs
+++ b/MediaServices.Client.Extensions.Tests/MediaServicesExceptionParserFixture.cs
@@ -85,6 +85,5 @@ namespace MediaServices.Client.Extensions.Tests
 
             Assert.IsNull(parsedException);
         }
-
     }
 }

--- a/MediaServices.Client.Extensions.Tests/Mocks/JobMock.cs
+++ b/MediaServices.Client.Extensions.Tests/Mocks/JobMock.cs
@@ -13,8 +13,6 @@
 // limitations under the License.
 // </license>
 
-using System.Diagnostics.CodeAnalysis;
-
 namespace MediaServices.Client.Extensions.Tests.Mocks
 {
     using System;

--- a/MediaServices.Client.Extensions.Tests/Mocks/MediaContextBaseMock.cs
+++ b/MediaServices.Client.Extensions.Tests/Mocks/MediaContextBaseMock.cs
@@ -13,13 +13,12 @@
 // limitations under the License.
 // </license>
 
-using Microsoft.WindowsAzure.MediaServices.Client.ContentKeyAuthorization;
-using Microsoft.WindowsAzure.MediaServices.Client.DynamicEncryption;
-
 namespace MediaServices.Client.Extensions.Tests.Mocks
 {
     using System;
     using Microsoft.WindowsAzure.MediaServices.Client;
+    using Microsoft.WindowsAzure.MediaServices.Client.ContentKeyAuthorization;
+    using Microsoft.WindowsAzure.MediaServices.Client.DynamicEncryption;
 
     public class MediaContextBaseMock : MediaContextBase
     {
@@ -37,32 +36,55 @@ namespace MediaServices.Client.Extensions.Tests.Mocks
         }
 
         public override ContentKeyAuthorizationPolicyOptionCollection ContentKeyAuthorizationPolicyOptions { get { throw new NotImplementedException(); } }
+
         public override ContentKeyAuthorizationPolicyCollection ContentKeyAuthorizationPolicies { get { throw new NotImplementedException(); } }
+
         public override AssetDeliveryPolicyCollection AssetDeliveryPolicies { get { throw new NotImplementedException(); } }
+
         public override ChannelBaseCollection Channels { get { throw new NotImplementedException(); } }
+
         public override ProgramBaseCollection Programs { get { throw new NotImplementedException(); } }
+
         public override StreamingEndpointBaseCollection StreamingEndpoints { get { throw new NotImplementedException(); } }
+
         public override OperationBaseCollection Operations { get { throw new NotImplementedException(); } }
+
         public override AccessPolicyBaseCollection AccessPolicies { get { throw new NotImplementedException(); } }
+
         public override AssetBaseCollection Assets { get { throw new NotImplementedException(); } }
+
         public override ContentKeyBaseCollection ContentKeys { get { throw new NotImplementedException(); } }
 
-        public override EncodingReservedUnitCollection EncodingReservedUnits
-        {
-            get { throw new NotImplementedException(); }
-        }
+        public override EncodingReservedUnitCollection EncodingReservedUnits { get { throw new NotImplementedException(); } }
 
         public override IStorageAccount DefaultStorageAccount { get { throw new NotImplementedException(); } }
+
         public override AssetFileBaseCollection Files { get { throw new NotImplementedException(); } }
+
         public override IngestManifestAssetCollection IngestManifestAssets { get { throw new NotImplementedException(); } }
+
         public override IngestManifestFileCollection IngestManifestFiles { get { throw new NotImplementedException(); } }
+
         public override IngestManifestCollection IngestManifests { get { throw new NotImplementedException(); } }
+
         public override JobBaseCollection Jobs { get { throw new NotImplementedException(); } }
+
         public override JobTemplateBaseCollection JobTemplates { get { throw new NotImplementedException(); } }
+
         public override LocatorBaseCollection Locators { get { throw new NotImplementedException(); } }
+
         public override MediaProcessorBaseCollection MediaProcessors { get { throw new NotImplementedException(); } }
+
         public override NotificationEndPointCollection NotificationEndPoints { get { throw new NotImplementedException(); } }
+
         public override StorageAccountBaseCollection StorageAccounts { get { return _storageAccounts; } }
+
         public override StreamingFilterBaseCollection Filters { get { throw new NotImplementedException(); } }
+
+        public override ChannelMetricsCollection ChannelMetrics { get { throw new NotImplementedException(); } }
+
+        public override MonitoringConfigurationCollection MonitoringConfigurations { get { throw new NotImplementedException(); } }
+
+        public override StreamingEndPointRequestLogCollection StreamingEndPointRequestLogs { get { throw new NotImplementedException(); } }
     }
 }

--- a/MediaServices.Client.Extensions.Tests/Mocks/TaskMock.cs
+++ b/MediaServices.Client.Extensions.Tests/Mocks/TaskMock.cs
@@ -42,7 +42,7 @@ namespace MediaServices.Client.Extensions.Tests.Mocks
         public DateTime? StartTime { get; set; }
 
         public DateTime? EndTime { get; set; }
-        
+
         public string PerfMessage { get; set; }
 
         public int Priority { get; set; }
@@ -62,6 +62,8 @@ namespace MediaServices.Client.Extensions.Tests.Mocks
         public InputAssetCollection<IAsset> InputAssets { get; set; }
 
         public OutputAssetCollection OutputAssets { get; set; }
+
+        public TaskNotificationSubscriptionCollection TaskNotificationSubscriptions { get { throw new NotImplementedException(); } }
 
         public string GetClearConfiguration()
         {

--- a/MediaServices.Client.Extensions.Tests/OutputAssetExtensionsFixture.cs
+++ b/MediaServices.Client.Extensions.Tests/OutputAssetExtensionsFixture.cs
@@ -25,7 +25,6 @@ namespace MediaServices.Client.Extensions.Tests
     [TestClass]
     public class OutputAssetExtensionsFixture
     {
-
         public readonly string Preset = "H264 Broadband SD 4x3";
         private readonly string smallWmv = @"Media\smallwmv1.wmv";
         private CloudMediaContext context;
@@ -60,7 +59,6 @@ namespace MediaServices.Client.Extensions.Tests
 
             return mp;
         }
-
 
         [TestMethod]
         [DeploymentItem(@"Media\smallwmv1.wmv", "Media")]

--- a/MediaServices.Client.Extensions.Tests/OutputAssetExtensionsFixture.cs
+++ b/MediaServices.Client.Extensions.Tests/OutputAssetExtensionsFixture.cs
@@ -14,20 +14,18 @@
 // limitations under the License.
 // </license>
 
-using System;
-using System.IO;
-
 namespace MediaServices.Client.Extensions.Tests
 {
+    using System;
+    using System.IO;
+    using System.Linq;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Microsoft.WindowsAzure.MediaServices.Client;
-    using System.Configuration;
-    using System.Linq;
 
     [TestClass]
     public class OutputAssetExtensionsFixture
     {
-        
+
         public readonly string Preset = "H264 Broadband SD 4x3";
         private readonly string smallWmv = @"Media\smallwmv1.wmv";
         private CloudMediaContext context;
@@ -78,11 +76,11 @@ namespace MediaServices.Client.Extensions.Tests
             file.Upload(inputAssetFilePath);
 
             IJob job = context.Jobs.Create("Job to test using an account selection strategy for an output asset");
-            ITask task = job.Tasks.AddNew("Task to test using an account selection strategy for an output asset", GetMediaProcessor(MediaProcessorNames.AzureMediaEncoder), Preset, TaskOptions.None);
+            ITask task = job.Tasks.AddNew("Task to test using an account selection strategy for an output asset", GetMediaProcessor(MediaProcessorNames.MediaEncoderStandard), Preset, TaskOptions.None);
             task.InputAssets.Add(inputAsset);
             task.OutputAssets.AddNew("OutputAsset", strategy, AssetCreationOptions.None);
 
-            job.Submit();       
+            job.Submit();
 
             // Note that we don't want for the job to finish.  We just need the submit to succeed.
             IJob refreshedJob = context.Jobs.Where(c => c.Id == job.Id).FirstOrDefault();

--- a/MediaServices.Client.Extensions.Tests/OutputAssetExtensionsFixture.cs
+++ b/MediaServices.Client.Extensions.Tests/OutputAssetExtensionsFixture.cs
@@ -19,16 +19,17 @@ namespace MediaServices.Client.Extensions.Tests
     using System;
     using System.IO;
     using System.Linq;
+    using System.Threading;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Microsoft.WindowsAzure.MediaServices.Client;
 
     [TestClass]
     public class OutputAssetExtensionsFixture
     {
-        public readonly string Preset = "H264 Broadband SD 4x3";
         private readonly string smallWmv = @"Media\smallwmv1.wmv";
         private CloudMediaContext context;
-        private IAsset asset;
+        private IAsset inputAsset;
+        private IAsset outputAsset;
 
         public TestContext TestContext { get; set; }
 
@@ -36,28 +37,22 @@ namespace MediaServices.Client.Extensions.Tests
         public void Initialize()
         {
             this.context = TestHelper.CreateContext();
-            this.asset = null;
+            this.inputAsset = null;
+            this.outputAsset = null;
         }
 
         [TestCleanup]
         public void Cleanup()
         {
-            if (this.asset != null)
+            if (this.inputAsset != null)
             {
-                this.asset.Delete();
-            }
-        }
-
-        private IMediaProcessor GetMediaProcessor(string mpName)
-        {
-            IMediaProcessor mp = context.MediaProcessors.Where(c => c.Name == mpName).ToList().OrderByDescending(c => new Version(c.Version)).FirstOrDefault();
-
-            if (mp == null)
-            {
-                throw new ArgumentException(string.Format("Media Processor {0} is not found", mpName), "mpName");
+                this.inputAsset.Delete();
             }
 
-            return mp;
+            if (this.outputAsset != null)
+            {
+                this.outputAsset.Delete();
+            }
         }
 
         [TestMethod]
@@ -69,23 +64,29 @@ namespace MediaServices.Client.Extensions.Tests
             string inputAssetFilePath = Path.Combine(TestContext.TestDeploymentDir, smallWmv);
             string inputAssetFileName = Path.GetFileName(inputAssetFilePath);
 
-            IAsset inputAsset = context.Assets.Create("", strategy, AssetCreationOptions.StorageEncrypted);
-            IAssetFile file = inputAsset.AssetFiles.Create(inputAssetFileName);
+            this.inputAsset = context.Assets.Create("InputAsset", strategy, AssetCreationOptions.StorageEncrypted);
+            IAssetFile file = this.inputAsset.AssetFiles.Create(inputAssetFileName);
             file.Upload(inputAssetFilePath);
 
             IJob job = context.Jobs.Create("Job to test using an account selection strategy for an output asset");
-            ITask task = job.Tasks.AddNew("Task to test using an account selection strategy for an output asset", GetMediaProcessor(MediaProcessorNames.MediaEncoderStandard), Preset, TaskOptions.None);
-            task.InputAssets.Add(inputAsset);
+            ITask task = job.Tasks.AddNew(
+                "Task to test using an account selection strategy for an output asset",
+                context.MediaProcessors.GetLatestMediaProcessorByName(MediaProcessorNames.MediaEncoderStandard),
+                MediaEncoderStandardTaskPresetStrings.H264SingleBitrate4x3SD,
+                TaskOptions.None);
+            task.InputAssets.Add(this.inputAsset);
             task.OutputAssets.AddNew("OutputAsset", strategy, AssetCreationOptions.None);
 
             job.Submit();
+            job.GetExecutionProgressTask(CancellationToken.None).Wait();
 
-            // Note that we don't want for the job to finish.  We just need the submit to succeed.
-            IJob refreshedJob = context.Jobs.Where(c => c.Id == job.Id).FirstOrDefault();
-            Assert.IsNotNull(refreshedJob);
-            Assert.AreEqual(1, refreshedJob.Tasks.Count, "Unexpected number of tasks in job");
-            Assert.AreEqual(1, refreshedJob.Tasks[0].OutputAssets.Count, "Unexpected number of output assets in the job");
-            Assert.IsNotNull(refreshedJob.Tasks[0].OutputAssets[0].StorageAccountName, "Storage account name in output assset is null");
+            Assert.IsNotNull(job);
+            Assert.AreEqual(1, job.Tasks.Count, "Unexpected number of tasks in job");
+            Assert.AreEqual(1, job.OutputMediaAssets.Count, "Unexpected number of output assets in the job");
+
+            this.outputAsset = job.OutputMediaAssets[0];
+
+            Assert.IsNotNull(outputAsset.StorageAccountName, "Storage account name in output assset is null");
         }
     }
 }

--- a/MediaServices.Client.Extensions.Tests/Properties/AssemblyInfo.cs
+++ b/MediaServices.Client.Extensions.Tests/Properties/AssemblyInfo.cs
@@ -46,5 +46,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.5.2.0")]
-[assembly: AssemblyFileVersion("3.5.2.0")]
+[assembly: AssemblyVersion("3.7.0.1")]
+[assembly: AssemblyFileVersion("3.7.0.1")]

--- a/MediaServices.Client.Extensions.Tests/TestHelper.cs
+++ b/MediaServices.Client.Extensions.Tests/TestHelper.cs
@@ -17,8 +17,10 @@ namespace MediaServices.Client.Extensions.Tests
 {
     using System;
     using System.Configuration;
-    ﻿using Microsoft.WindowsAzure.MediaServices.Client;
+    using Microsoft.WindowsAzure.MediaServices.Client;
+    using Microsoft.WindowsAzure.Storage;
     using Microsoft.WindowsAzure.Storage.Auth;
+    using Microsoft.WindowsAzure.Storage.Blob;
 
     public class TestHelper
     {
@@ -45,6 +47,13 @@ namespace MediaServices.Client.Extensions.Tests
             return new StorageCredentials(
                 ConfigurationManager.AppSettings["MediaServiceStorageAccountName"],
                 ConfigurationManager.AppSettings["MediaServiceStorageAccountKey"]);
+        }
+
+        public static CloudBlobClient CreateCloudBlobClient()
+        {
+            var storageAccount = new CloudStorageAccount(CreateStorageCredentials(), true);
+
+            return storageAccount.CreateCloudBlobClient();
         }
     }
 }

--- a/MediaServices.Client.Extensions.Tests/packages.config
+++ b/MediaServices.Client.Extensions.Tests/packages.config
@@ -9,6 +9,6 @@
   <package id="System.IdentityModel.Tokens.Jwt" version="4.0.2.205111437" targetFramework="net45" />
   <package id="System.Spatial" version="5.6.4" targetFramework="net45" />
   <package id="TransientFaultHandling.Core" version="5.1.1209.1" targetFramework="net40" />
-  <package id="windowsazure.mediaservices" version="3.5.2.0" targetFramework="net45" />
+  <package id="windowsazure.mediaservices" version="3.7.0.1" targetFramework="net45" />
   <package id="WindowsAzure.Storage" version="4.3.0.0" targetFramework="net40" />
 </packages>

--- a/MediaServices.Client.Extensions/CapacityBasedAccountSelectionStrategy.cs
+++ b/MediaServices.Client.Extensions/CapacityBasedAccountSelectionStrategy.cs
@@ -14,13 +14,12 @@
 // limitations under the License.
 // </license>
 
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-
 namespace Microsoft.WindowsAzure.MediaServices.Client
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
     /// <summary>
     /// This IAccountSelectionStrategy implementation uses the number of used bytes in a storage account to help determine which storage account
     /// should be used to create the next asset.  It relies on the capacity metrics of the blob storage service to get the number of bytes used
@@ -84,7 +83,7 @@ namespace Microsoft.WindowsAzure.MediaServices.Client
                 throw new ArgumentNullException("mediaContextBase");
             }
 
-            CapacityBasedAccountSelectionStrategy strategy = new CapacityBasedAccountSelectionStrategy(mediaContextBase);                      
+            CapacityBasedAccountSelectionStrategy strategy = new CapacityBasedAccountSelectionStrategy(mediaContextBase);
 
             foreach (IStorageAccount storageAccount in GetAllStorageAccounts(mediaContextBase))
             {
@@ -281,5 +280,4 @@ namespace Microsoft.WindowsAzure.MediaServices.Client
             return storageAccounts.AsEnumerable<IStorageAccount>();
         }
     }
-
 }

--- a/MediaServices.Client.Extensions/CopyBlobHelpers.cs
+++ b/MediaServices.Client.Extensions/CopyBlobHelpers.cs
@@ -1,0 +1,97 @@
+﻿// <copyright file="CopyBlobHelpers.cs" company="Microsoft">Copyright 2013 Microsoft Corporation</copyright>
+// <license>
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </license>
+
+namespace Microsoft.WindowsAzure.MediaServices.Client
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.WindowsAzure.Storage;
+    using Microsoft.WindowsAzure.Storage.Blob;
+
+    /// <summary>
+    /// Contains helper methods for copying blobs.
+    /// </summary>
+    public static class CopyBlobHelpers
+    {
+        /// <summary>
+        /// Represents the maximum number of concurrent Copy Blob operations when copying content from a source container to a destination container.
+        /// </summary>
+        public const int MaxNumberOfConcurrentCopyFromBlobOperations = 750;
+
+        /// <summary>
+        /// Returns a <see cref="System.Threading.Tasks.Task"/> instance for the copy blobs operation from <paramref name="sourceContainer"/> to <paramref name="destinationContainer"/>.
+        /// </summary>
+        /// <param name="sourceContainer">The <see cref="Microsoft.WindowsAzure.Storage.Blob.CloudBlobContainer"/> instance that contains the blobs to be copied into <paramref name="destinationContainer"/>.</param>
+        /// <param name="destinationContainer">The <see cref="Microsoft.WindowsAzure.Storage.Blob.CloudBlobContainer"/> instance where the blobs from <paramref name="sourceContainer"/> will be copied.</param>
+        /// <param name="options">The <see cref="Microsoft.WindowsAzure.Storage.Blob.BlobRequestOptions"/>.</param>
+        /// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> instance used for cancellation.</param>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> instance for the copy blobs operation from <paramref name="sourceContainer"/> to <paramref name="destinationContainer"/>.</returns>
+        public static async Task CopyBlobsAsync(CloudBlobContainer sourceContainer, CloudBlobContainer destinationContainer, BlobRequestOptions options, CancellationToken cancellationToken)
+        {
+            BlobContinuationToken continuationToken = null;
+
+            do
+            {
+                BlobResultSegment resultSegment = await sourceContainer.ListBlobsSegmentedAsync(null, true, BlobListingDetails.None, MaxNumberOfConcurrentCopyFromBlobOperations, continuationToken, options, null, cancellationToken).ConfigureAwait(false);
+
+                IEnumerable<Task> copyTasks = resultSegment
+                    .Results
+                    .Cast<CloudBlockBlob>()
+                    .Select(
+                        sourceBlob =>
+                        {
+                            CloudBlockBlob destinationBlob = destinationContainer.GetBlockBlobReference(sourceBlob.Name);
+
+                            return CopyBlobAsync(sourceBlob, destinationBlob, options, cancellationToken);
+                        });
+
+                await Task.WhenAll(copyTasks).ConfigureAwait(false);
+                cancellationToken.ThrowIfCancellationRequested();
+
+                continuationToken = resultSegment.ContinuationToken;
+            }
+            while (continuationToken != null);
+        }
+
+        /// <summary>
+        /// Returns a <see cref="System.Threading.Tasks.Task"/> instance for the copy blob operation from <paramref name="sourceBlob"/> to <paramref name="destinationBlob"/>.
+        /// </summary>
+        /// <param name="sourceBlob">The <see cref="Microsoft.WindowsAzure.Storage.Blob.CloudBlockBlob"/> instance to be copied to <paramref name="destinationBlob"/>.</param>
+        /// <param name="destinationBlob">The <see cref="Microsoft.WindowsAzure.Storage.Blob.CloudBlockBlob"/> instance where <paramref name="sourceBlob"/> will be copied.</param>
+        /// <param name="options">The <see cref="Microsoft.WindowsAzure.Storage.Blob.BlobRequestOptions"/>.</param>
+        /// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> instance used for cancellation.</param>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> instance for the copy blob operation from <paramref name="sourceBlob"/> to <paramref name="destinationBlob"/>.</returns>
+        public static async Task CopyBlobAsync(CloudBlockBlob sourceBlob, CloudBlockBlob destinationBlob, BlobRequestOptions options, CancellationToken cancellationToken)
+        {
+            await destinationBlob.StartCopyFromBlobAsync(sourceBlob, null, null, options, null, cancellationToken).ConfigureAwait(false);
+
+            CopyState copyState = destinationBlob.CopyState;
+            while (copyState == null || copyState.Status == CopyStatus.Pending)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                await destinationBlob.FetchAttributesAsync(null, options, null, cancellationToken).ConfigureAwait(false);
+
+                copyState = destinationBlob.CopyState;
+                if (copyState != null && copyState.Status != CopyStatus.Pending && copyState.Status != CopyStatus.Success)
+                {
+                    throw new StorageException(copyState.StatusDescription);
+                }
+            }
+        }
+    }
+}

--- a/MediaServices.Client.Extensions/IJobExtensions.cs
+++ b/MediaServices.Client.Extensions/IJobExtensions.cs
@@ -125,6 +125,5 @@ namespace Microsoft.WindowsAzure.MediaServices.Client
 
             return context;
         }
-
     }
 }

--- a/MediaServices.Client.Extensions/ILocatorExtensions.cs
+++ b/MediaServices.Client.Extensions/ILocatorExtensions.cs
@@ -29,6 +29,11 @@ namespace Microsoft.WindowsAzure.MediaServices.Client
         public const string ManifestFileExtension = ".ism";
 
         /// <summary>
+        /// Represents the client manifest file extension for Smooth Streaming.
+        /// </summary>
+        public const string ClientManifestFileExtension = ".ismc";
+
+        /// <summary>
         /// Represents the URL dynamic packaging parameter for HLS.
         /// </summary>
         public const string HlsStreamingParameter = "(format=m3u8-aapl)";

--- a/MediaServices.Client.Extensions/MediaEncoderStandardTaskPresetStrings.cs
+++ b/MediaServices.Client.Extensions/MediaEncoderStandardTaskPresetStrings.cs
@@ -1,0 +1,182 @@
+﻿// <copyright file="MediaEncoderStandardTaskPresetStrings.cs" company="Microsoft">Copyright 2013 Microsoft Corporation</copyright>
+// <license>
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </license>
+
+namespace Microsoft.WindowsAzure.MediaServices.Client
+{
+    /// <summary>
+    /// Contains string constants with the available Task Preset Strings for Media Encoder Standard (MES).
+    /// For more information, please visit <a href="https://msdn.microsoft.com/library/azure/mt269960.aspx">https://msdn.microsoft.com/library/azure/mt269960.aspx</a>.
+    /// </summary>
+    public static class MediaEncoderStandardTaskPresetStrings
+    {
+        #region H264 Multiple Bitrate Presets
+
+        /// <summary>
+        /// Produces a set of 8 GOP-aligned MP4 files, ranging from 6000 kbps to 400 kbps, and AAC 5.1 audio.
+        /// For more information, please visit <a href="https://msdn.microsoft.com/library/azure/mt269929.aspx">https://msdn.microsoft.com/library/azure/mt269929.aspx</a>.
+        /// </summary>
+        public const string H264MultipleBitrate1080pAudio51 = "H264 Multiple Bitrate 1080p Audio 5.1";
+
+        /// <summary>
+        /// Produces a set of 8 GOP-aligned MP4 files, ranging from 6000 kbps to 400 kbps, and stereo AAC audio.
+        /// For more information, please visit <a href="https://msdn.microsoft.com/library/azure/mt269937.aspx">https://msdn.microsoft.com/library/azure/mt269937.aspx</a>.
+        /// </summary>
+        public const string H264MultipleBitrate1080p = "H264 Multiple Bitrate 1080p";
+
+        /// <summary>
+        /// Produces a set of 8 GOP-aligned MP4 files, ranging from 8500 kbps to 200 kbps, and stereo AAC audio.
+        /// For more information, please visit <a href="https://msdn.microsoft.com/library/azure/mt269925.aspx">https://msdn.microsoft.com/library/azure/mt269925.aspx</a>.
+        /// </summary>
+        public const string H264MultipleBitrate16x9foriOS = "H264 Multiple Bitrate 16x9 for iOS";
+
+        /// <summary>
+        /// Produces a set of 5 GOP-aligned MP4 files, ranging from 1900 kbps to 400 kbps, and AAC 5.1 audio.
+        /// For more information, please visit <a href="https://msdn.microsoft.com/library/azure/mt269939.aspx">https://msdn.microsoft.com/library/azure/mt269939.aspx</a>.
+        /// </summary>
+        public const string H264MultipleBitrate16x9SDAudio51 = "H264 Multiple Bitrate 16x9 SD Audio 5.1";
+
+        /// <summary>
+        /// Produces a set of 5 GOP-aligned MP4 files, ranging from 1900 kbps to 400 kbps, and stereo AAC audio.
+        /// For more information, please visit <a href="https://msdn.microsoft.com/library/azure/mt269954.aspx">https://msdn.microsoft.com/library/azure/mt269954.aspx</a>.
+        /// </summary>
+        public const string H264MultipleBitrate16x9SD = "H264 Multiple Bitrate 16x9 SD";
+
+        /// <summary>
+        /// Produces a set of 12 GOP-aligned MP4 files, ranging from 20000 kbps to 1000 kbps, and AAC 5.1 audio.
+        /// For more information, please visit <a href="https://msdn.microsoft.com/library/azure/mt269950.aspx">https://msdn.microsoft.com/library/azure/mt269950.aspx</a>.
+        /// </summary>
+        public const string H264MultipleBitrate4KAudio51 = "H264 Multiple Bitrate 4K Audio 5.1";
+
+        /// <summary>
+        /// Produces a set of 12 GOP-aligned MP4 files, ranging from 20000 kbps to 1000 kbps, and stereo AAC audio.
+        /// For more information, please visit <a href="https://msdn.microsoft.com/library/azure/mt269933.aspx">https://msdn.microsoft.com/library/azure/mt269933.aspx</a>.
+        /// </summary>
+        public const string H264MultipleBitrate4K = "H264 Multiple Bitrate 4K";
+
+        /// <summary>
+        /// Produces a set of 8 GOP-aligned MP4 files, ranging from 8500 kbps to 200 kbps, and stereo AAC audio.
+        /// For more information, please visit <a href="https://msdn.microsoft.com/library/azure/mt269947.aspx">https://msdn.microsoft.com/library/azure/mt269947.aspx</a>.
+        /// </summary>
+        public const string H264MultipleBitrate4x3foriOS = "H264 Multiple Bitrate 4x3 for iOS";
+
+        /// <summary>
+        /// Produces a set of 5 GOP-aligned MP4 files, ranging from 1600 kbps to 400 kbps, and AAC 5.1 audio.
+        /// For more information, please visit <a href="https://msdn.microsoft.com/library/azure/mt269931.aspx">https://msdn.microsoft.com/library/azure/mt269931.aspx</a>.
+        /// </summary>
+        public const string H264MultipleBitrate4x3SDAudio51 = "H264 Multiple Bitrate 4x3 SD Audio 5.1";
+
+        /// <summary>
+        /// Produces a set of 5 GOP-aligned MP4 files, ranging from 1600 kbps to 400 kbps, and stereo AAC audio.
+        /// For more information, please visit <a href="https://msdn.microsoft.com/library/azure/mt269963.aspx">https://msdn.microsoft.com/library/azure/mt269963.aspx</a>.
+        /// </summary>
+        public const string H264MultipleBitrate4x3SD = "H264 Multiple Bitrate 4x3 SD";
+
+        /// <summary>
+        /// Produces a set of 6 GOP-aligned MP4 files, ranging from 3400 kbps to 400 kbps, and AAC 5.1 audio.
+        /// For more information, please visit <a href="https://msdn.microsoft.com/library/azure/mt269941.aspx">https://msdn.microsoft.com/library/azure/mt269941.aspx</a>.
+        /// </summary>
+        public const string H264MultipleBitrate720pAudio51 = "H264 Multiple Bitrate 720p Audio 5.1";
+
+        /// <summary>
+        /// Produces a set of 6 GOP-aligned MP4 files, ranging from 3400 kbps to 400 kbps, and stereo AAC audio.
+        /// For more information, please visit <a href="https://msdn.microsoft.com/library/azure/mt269953.aspx">https://msdn.microsoft.com/library/azure/mt269953.aspx</a>.
+        /// </summary>
+        public const string H264MultipleBitrate720p = "H264 Multiple Bitrate 720p";
+
+        #endregion
+
+        #region H264 Single Bitrate Presets
+
+        /// <summary>
+        /// Produces a single MP4 file with a bitrate of 6750 kbps, and AAC 5.1 audio.
+        /// For more information, please visit <a href="https://msdn.microsoft.com/library/azure/mt269928.aspx">https://msdn.microsoft.com/library/azure/mt269928.aspx</a>.
+        /// </summary>
+        public const string H264SingleBitrate1080pAudio51 = "H264 Single Bitrate 1080p Audio 5.1";
+
+        /// <summary>
+        /// Produces a single MP4 file with a bitrate of 6750 kbps, and stereo AAC audio.
+        /// For more information, please visit <a href="https://msdn.microsoft.com/library/azure/mt269926.aspx">https://msdn.microsoft.com/library/azure/mt269926.aspx</a>.
+        /// </summary>
+        public const string H264SingleBitrate1080p = "H264 Single Bitrate 1080p";
+
+        /// <summary>
+        /// Produces a single MP4 file with a bitrate of 18000 kbps, and AAC 5.1 audio.
+        /// For more information, please visit <a href="https://msdn.microsoft.com/library/azure/mt269942.aspx">https://msdn.microsoft.com/library/azure/mt269942.aspx</a>.
+        /// </summary>
+        public const string H264SingleBitrate4KAudio51 = "H264 Single Bitrate 4K Audio 5.1";
+
+        /// <summary>
+        /// Produces a single MP4 file with a bitrate of 18000 kbps, and stereo AAC audio.
+        /// For more information, please visit <a href="https://msdn.microsoft.com/library/azure/mt269936.aspx">https://msdn.microsoft.com/library/azure/mt269936.aspx</a>.
+        /// </summary>
+        public const string H264SingleBitrate4K = "H264 Single Bitrate 4K";
+
+        /// <summary>
+        /// Produces a single MP4 file with a bitrate of 18000 kbps, and AAC 5.1 audio.
+        /// For more information, please visit <a href="https://msdn.microsoft.com/library/azure/mt269927.aspx">https://msdn.microsoft.com/library/azure/mt269927.aspx</a>.
+        /// </summary>
+        public const string H264SingleBitrate4x3SDAudio51 = "H264 Single Bitrate 4x3 SD Audio 5.1";
+
+        /// <summary>
+        /// Produces a single MP4 file with a bitrate of 18000 kbps, and stereo AAC audio.
+        /// For more information, please visit <a href="https://msdn.microsoft.com/library/azure/mt269956.aspx">https://msdn.microsoft.com/library/azure/mt269956.aspx</a>.
+        /// </summary>
+        public const string H264SingleBitrate4x3SD = "H264 Single Bitrate 4x3 SD";
+
+        /// <summary>
+        /// Produces a single MP4 file with a bitrate of 2200 kbps, and AAC 5.1 audio.
+        /// For more information, please visit <a href="https://msdn.microsoft.com/library/azure/mt269944.aspx">https://msdn.microsoft.com/library/azure/mt269944.aspx</a>.
+        /// </summary>
+        public const string H264SingleBitrate16x9SDAudio51 = "H264 Single Bitrate 16x9 SD Audio 5.1";
+
+        /// <summary>
+        /// Produces a single MP4 file with a bitrate of 2200 kbps, and stereo AAC audio.
+        /// For more information, please visit <a href="https://msdn.microsoft.com/library/azure/mt269934.aspx">https://msdn.microsoft.com/library/azure/mt269934.aspx</a>.
+        /// </summary>
+        public const string H264SingleBitrate16x9SD = "H264 Single Bitrate 16x9 SD";
+
+        /// <summary>
+        /// Produces a single MP4 file with a bitrate of 4500 kbps, and AAC 5.1 audio.
+        /// For more information, please visit <a href="https://msdn.microsoft.com/library/azure/mt269930.aspx">https://msdn.microsoft.com/library/azure/mt269930.aspx</a>.
+        /// </summary>
+        public const string H264SingleBitrate720pAudio51 = "H264 Single Bitrate 720p Audio 5.1";
+
+        /// <summary>
+        /// Produces a single MP4 file with a bitrate of 2000 kbps, and stereo AAC.
+        /// For more information, please visit <a href="https://msdn.microsoft.com/library/azure/mt269965.aspx">https://msdn.microsoft.com/library/azure/mt269965.aspx</a>.
+        /// </summary>
+        public const string H264SingleBitrate720pforAndroid = "H264 Single Bitrate 720p for Android";
+
+        /// <summary>
+        /// Produces a single MP4 file with a bitrate of 4500 kbps, and stereo AAC audio.
+        /// For more information, please visit <a href="https://msdn.microsoft.com/library/azure/mt269949.aspx">https://msdn.microsoft.com/library/azure/mt269949.aspx</a>.
+        /// </summary>
+        public const string H264SingleBitrate720p = "H264 Single Bitrate 720p";
+
+        /// <summary>
+        /// Produces a single MP4 file with a bitrate of 500 kbps, and stereo AAC audio.
+        /// For more information, please visit <a href="https://msdn.microsoft.com/library/azure/mt269964.aspx">https://msdn.microsoft.com/library/azure/mt269964.aspx</a>.
+        /// </summary>
+        public const string H264SingleBitrateHighQualitySDforAndroid = "H264 Single Bitrate High Quality SD for Android";
+
+        /// <summary>
+        /// Produces a single MP4 file with a bitrate of 56 kbps, and stereo AAC audio.
+        /// For more information, please visit <a href="https://msdn.microsoft.com/library/azure/mt269948.aspx">https://msdn.microsoft.com/library/azure/mt269948.aspx</a>.
+        /// </summary>
+        public const string H264SingleBitrateLowQualitySDforAndroid = "H264 Single Bitrate Low Quality SD for Android";
+
+        #endregion
+    }
+}

--- a/MediaServices.Client.Extensions/MediaEncoderTaskPresetStrings.cs
+++ b/MediaServices.Client.Extensions/MediaEncoderTaskPresetStrings.cs
@@ -15,10 +15,13 @@
 
 namespace Microsoft.WindowsAzure.MediaServices.Client
 {
+    using System;
+
     /// <summary>
     /// Contains string constants with the available Task Preset Strings for Windows Azure Media Encoder.
     /// For more information, please visit <a href="http://msdn.microsoft.com/library/windowsazure/jj129582.aspx">http://msdn.microsoft.com/library/windowsazure/jj129582.aspx</a>.
     /// </summary>
+    [Obsolete]
     public static class MediaEncoderTaskPresetStrings
     {
         #region Audio Coding Standard

--- a/MediaServices.Client.Extensions/MediaProcessorNames.cs
+++ b/MediaServices.Client.Extensions/MediaProcessorNames.cs
@@ -23,50 +23,87 @@ namespace Microsoft.WindowsAzure.MediaServices.Client
     public static class MediaProcessorNames
     {
         /// <summary>
+        /// Lets you run encoding tasks using the processor 'Azure Media Face Detector'.
+        /// </summary>
+        public const string AzureMediaFaceDetector = "Azure Media Face Detector";
+
+        /// <summary>
+        /// Lets you run encoding tasks using the processor 'Azure Media Hyperlapse'.
+        /// </summary>
+        public const string AzureMediaHyperlapse = "Azure Media Hyperlapse";
+
+        /// <summary>
+        /// Lets you run encoding tasks using the processor 'Azure Media Indexer'.
+        /// </summary>
+        public const string AzureMediaIndexer = "Azure Media Indexer";
+
+        /// <summary>
+        /// Lets you run encoding tasks using the processor 'Azure Media Indexer 2 Preview'.
+        /// </summary>
+        public const string AzureMediaIndexer2Preview = "Azure Media Indexer 2 Preview";
+
+        /// <summary>
+        /// Lets you run encoding tasks using the processor 'Azure Media Motion Detector'.
+        /// </summary>
+        public const string AzureMediaMotionDetector = "Azure Media Motion Detector";
+
+        /// <summary>
+        /// Lets you run encoding tasks using the processor 'Azure Media OCR'.
+        /// </summary>
+        public const string AzureMediaOCR = "Azure Media OCR";
+
+        /// <summary>
+        /// Lets you run encoding tasks using the processor 'Azure Media Stabilizer'.
+        /// </summary>
+        public const string AzureMediaStabilizer = "Azure Media Stabilizer";
+
+        /// <summary>
+        /// Lets you run encoding tasks using the processor 'Azure Media Video Thumbnails'.
+        /// </summary>
+        public const string AzureMediaVideoThumbnails = "Azure Media Video Thumbnails";
+
+        /// <summary>
+        /// Lets you run encoding tasks using the processor 'Media Encoder Premium Workflow'.
+        /// </summary>
+        public const string MediaEncoderPremiumWorkflow = "Media Encoder Premium Workflow";
+
+        /// <summary>
+        /// Lets you run encoding tasks using the processor 'Media Encoder Standard'.
+        /// </summary>
+        public const string MediaEncoderStandard = "Media Encoder Standard";
+
+        /// <summary>
+        /// Lets you decrypt media assets that were encrypted using storage encryption.
+        /// </summary>
+        public const string StorageDecryption = "Storage Decryption";
+
+        #region Deprecated Processors
+
+        /// <summary>
         /// Lets you run encoding tasks using the processor 'Windows Azure Media Encoder'.
         /// </summary>
         [Obsolete]
         public const string WindowsAzureMediaEncoder = "Windows Azure Media Encoder";
 
         /// <summary>
-        ///  Lets you run encoding tasks using the processor 'Azure Media Encoder'.
+        /// Lets you run encoding tasks using the processor 'Azure Media Encoder'.
         /// </summary>
+        [Obsolete]
         public const string AzureMediaEncoder = "Azure Media Encoder";
-
-        /// <summary>
-        ///  Lets you run encoding tasks using the processor 'Azure Media Indexer'.
-        /// </summary>
-        public const string AzureMediaIndexer = "Azure Media Indexer";
-
-        /// <summary>
-        ///  Lets you run encoding tasks using the processor 'Azure Media Hyperlapse'.
-        /// </summary>
-        public const string AzureMediaHyperlapse = "Azure Media Hyperlapse";
-
-        /// <summary>
-        ///  Lets you run encoding tasks using the processor 'Media Encoder Standard'.
-        /// </summary>
-        public const string MediaEncoderStandard = "Media Encoder Standard";
-
-        /// <summary>
-        ///  Lets you run encoding tasks using the processor 'Media Encoder Premium Workflow'.
-        /// </summary>
-        public const string MediaEncoderPremiumWorkflow = "Media Encoder Premium Workflow";
 
         /// <summary>
         /// Lets you convert media assets from MP4 to Smooth Streaming format. Also, lets you convert media assets 
         /// from Smooth Streaming to the Apple HTTP Live Streaming (HLS) format.
         /// </summary>
+        [Obsolete]
         public const string WindowsAzureMediaPackager = "Windows Azure Media Packager";
 
         /// <summary>
         /// Lets you encrypt media assets using PlayReady Protection.
         /// </summary>
+        [Obsolete]
         public const string WindowsAzureMediaEncryptor = "Windows Azure Media Encryptor";
 
-        /// <summary>
-        /// Lets you decrypt media assets that were encrypted using storage encryption.
-        /// </summary>
-        public const string StorageDecryption = "Storage Decryption";
+        #endregion
     }
 }

--- a/MediaServices.Client.Extensions/MediaServices.Client.Extensions.csproj
+++ b/MediaServices.Client.Extensions/MediaServices.Client.Extensions.csproj
@@ -112,6 +112,7 @@
   <ItemGroup>
     <Compile Include="AssetBaseCollectionExtensions.cs" />
     <Compile Include="IAssetFileExtensions.cs" />
+    <Compile Include="MediaEncoderStandardTaskPresetStrings.cs" />
     <Compile Include="Metadata\AssetFileMetadata.cs" />
     <Compile Include="CapacityBasedAccountSelectionStrategyListEntry.cs" />
     <Compile Include="CapacityBasedAccountSelectionStrategy.cs" />

--- a/MediaServices.Client.Extensions/MediaServices.Client.Extensions.csproj
+++ b/MediaServices.Client.Extensions/MediaServices.Client.Extensions.csproj
@@ -70,17 +70,17 @@
       <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.1.8.0.0\lib\net35-full\Microsoft.WindowsAzure.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.MediaServices.Client, Version=3.5.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\windowsazure.mediaservices.3.5.2.0\lib\net45\Microsoft.WindowsAzure.MediaServices.Client.dll</HintPath>
+    <Reference Include="Microsoft.WindowsAzure.MediaServices.Client, Version=3.7.0.1, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\windowsazure.mediaservices.3.7.0.1\lib\net45\Microsoft.WindowsAzure.MediaServices.Client.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.MediaServices.Client.Common.BlobTransfer, Version=3.5.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\windowsazure.mediaservices.3.5.2.0\lib\net45\Microsoft.WindowsAzure.MediaServices.Client.Common.BlobTransfer.dll</HintPath>
+    <Reference Include="Microsoft.WindowsAzure.MediaServices.Client.Common.BlobTransfer, Version=3.7.0.1, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\windowsazure.mediaservices.3.7.0.1\lib\net45\Microsoft.WindowsAzure.MediaServices.Client.Common.BlobTransfer.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.MediaServices.Client.Common.FileEncryption, Version=3.5.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\windowsazure.mediaservices.3.5.2.0\lib\net45\Microsoft.WindowsAzure.MediaServices.Client.Common.FileEncryption.dll</HintPath>
+    <Reference Include="Microsoft.WindowsAzure.MediaServices.Client.Common.FileEncryption, Version=3.7.0.1, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\windowsazure.mediaservices.3.7.0.1\lib\net45\Microsoft.WindowsAzure.MediaServices.Client.Common.FileEncryption.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Storage, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\WindowsAzure.Storage.4.3.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>

--- a/MediaServices.Client.Extensions/MediaServices.Client.Extensions.csproj
+++ b/MediaServices.Client.Extensions/MediaServices.Client.Extensions.csproj
@@ -111,6 +111,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssetBaseCollectionExtensions.cs" />
+    <Compile Include="CopyBlobHelpers.cs" />
     <Compile Include="IAssetFileExtensions.cs" />
     <Compile Include="MediaEncoderStandardTaskPresetStrings.cs" />
     <Compile Include="Metadata\AssetFileMetadata.cs" />

--- a/MediaServices.Client.Extensions/Metadata/AssetFileMetadata.cs
+++ b/MediaServices.Client.Extensions/Metadata/AssetFileMetadata.cs
@@ -69,6 +69,7 @@ namespace Microsoft.WindowsAzure.MediaServices.Client.Metadata
 
             return assetFileMetadata;
         }
+
         private static IEnumerable<Source> ParseSources(XElement sourcesElement)
         {
             IEnumerable<Source> sources = null;

--- a/MediaServices.Client.Extensions/Metadata/AssetMetadataParser.cs
+++ b/MediaServices.Client.Extensions/Metadata/AssetMetadataParser.cs
@@ -76,6 +76,8 @@ namespace Microsoft.WindowsAzure.MediaServices.Client.Metadata
 
         internal static readonly XName EncoderVersionAttributeName = XName.Get("EncoderVersion");
 
+        internal static readonly XName LanguageAttributeName = XName.Get("Language");
+
         internal static async Task<IEnumerable<AssetFileMetadata>> ParseAssetFileMetadataAsync(Uri assetFileMetadataUri, IRetryPolicy retryPolicy, CancellationToken cancellationToken)
         {
             IList<AssetFileMetadata> assetFileMetadataList = new List<AssetFileMetadata>();

--- a/MediaServices.Client.Extensions/Metadata/AudioTrack.cs
+++ b/MediaServices.Client.Extensions/Metadata/AudioTrack.cs
@@ -51,6 +51,11 @@ namespace Microsoft.WindowsAzure.MediaServices.Client.Metadata
         public string Codec { get; internal set; }
 
         /// <summary>
+        /// Get the language.
+        /// </summary>
+        public string Language { get; internal set; }
+
+        /// <summary>
         /// Get the optional encoder version string, required for EAC3.
         /// </summary>
         public string EncoderVersion { get; internal set; }
@@ -71,6 +76,7 @@ namespace Microsoft.WindowsAzure.MediaServices.Client.Metadata
             audioTrack.SamplingRate = audioTrackElement.GetAttributeAsIntOrDefault(AssetMetadataParser.SamplingRateAttributeName);
             audioTrack.BitsPerSample = audioTrackElement.GetAttributeAsIntOrDefault(AssetMetadataParser.BitsPerSampleAttributeName);
             audioTrack.EncoderVersion = audioTrackElement.GetAttributeOrDefault(AssetMetadataParser.EncoderVersionAttributeName);
+            audioTrack.Language = audioTrackElement.GetAttributeOrDefault(AssetMetadataParser.LanguageAttributeName);
 
             return audioTrack;
         }

--- a/MediaServices.Client.Extensions/Metadata/VideoTrack.cs
+++ b/MediaServices.Client.Extensions/Metadata/VideoTrack.cs
@@ -74,6 +74,7 @@ namespace Microsoft.WindowsAzure.MediaServices.Client.Metadata
         /// Get the encoded video width in pixels.
         /// </summary>
         public int Width { get; internal set; }
+
         internal static VideoTrack Load(XElement videoTrackElement)
         {
             VideoTrack videoTrack = new VideoTrack();

--- a/MediaServices.Client.Extensions/Metadata/XmlElementExtensions.cs
+++ b/MediaServices.Client.Extensions/Metadata/XmlElementExtensions.cs
@@ -29,6 +29,7 @@ namespace Microsoft.WindowsAzure.MediaServices.Client.Metadata
         private const double DefaultDoubleAttributeValue = 0;
 
         private static readonly TimeSpan DefaultTimeSpanAttributeValue = TimeSpan.Zero;
+
         internal static string GetAttributeOrDefault(this XElement element, XName name)
         {
             string attributeValue = null;
@@ -41,6 +42,7 @@ namespace Microsoft.WindowsAzure.MediaServices.Client.Metadata
 
             return attributeValue;
         }
+
         internal static long GetAttributeAsLongOrDefault(this XElement element, XName name)
         {
             string attributeValueString = element.GetAttributeOrDefault(name);
@@ -53,6 +55,7 @@ namespace Microsoft.WindowsAzure.MediaServices.Client.Metadata
 
             return attributeValue;
         }
+
         internal static int GetAttributeAsIntOrDefault(this XElement element, XName name)
         {
             string attributeValueString = element.GetAttributeOrDefault(name);
@@ -65,6 +68,7 @@ namespace Microsoft.WindowsAzure.MediaServices.Client.Metadata
 
             return attributeValue;
         }
+
         internal static double GetAttributeAsDoubleOrDefault(this XElement element, XName name)
         {
             string attributeValueString = element.GetAttributeOrDefault(name);

--- a/MediaServices.Client.Extensions/OutputAssetCollectionExtensions.cs
+++ b/MediaServices.Client.Extensions/OutputAssetCollectionExtensions.cs
@@ -13,10 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </license>
-using System;
 
 namespace Microsoft.WindowsAzure.MediaServices.Client
 {
+    using System;
+
     public static class OutputAssetCollectionExtensions
     {
         /// <summary>
@@ -31,7 +32,7 @@ namespace Microsoft.WindowsAzure.MediaServices.Client
         {
             if (collection == null)
             {
-                throw new ArgumentNullException("collection");            
+                throw new ArgumentNullException("collection");
             }
 
             if (strategy == null)

--- a/MediaServices.Client.Extensions/Properties/AssemblyInfo.cs
+++ b/MediaServices.Client.Extensions/Properties/AssemblyInfo.cs
@@ -47,5 +47,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.5.2.0")]
-[assembly: AssemblyFileVersion("3.5.2.0")]
+[assembly: AssemblyVersion("3.7.0.1")]
+[assembly: AssemblyFileVersion("3.7.0.1")]

--- a/MediaServices.Client.Extensions/packages.config
+++ b/MediaServices.Client.Extensions/packages.config
@@ -8,6 +8,6 @@
   <package id="System.IdentityModel.Tokens.Jwt" version="4.0.2.205111437" targetFramework="net45" />
   <package id="System.Spatial" version="5.6.4" targetFramework="net45" />
   <package id="TransientFaultHandling.Core" version="5.1.1209.1" targetFramework="net45" />
-  <package id="windowsazure.mediaservices" version="3.5.2.0" targetFramework="net45" />
+  <package id="windowsazure.mediaservices" version="3.7.0.1" targetFramework="net45" />
   <package id="WindowsAzure.Storage" version="4.3.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
## Change Log

- Upgraded to Media Services .NET SDK v3.7.0.1 and fixed breaking changes
- Marked as obsolete these processors: Windows Azure Media Encoder, Azure Media Encoder, Windows Azure Media Packager, Windows Azure Media Encryptor
- Marked as obsolete the task preset strings for Azure Media Encoder processor
- Added names for new media analytic processors
- Added task preset strings for Media Encoder Standard processor: https://msdn.microsoft.com/library/azure/mt269960.aspx
- Updated unit tests to use Media Encoder Standard processor instead of Azure Media Encoder
- Added new CopyBlobHelpers static class with helper methods for copy blob operations
- Added new AssetBaseCollection.CreateFromBlobAsync / AssetBaseCollection.CreateFromBlob extensions
- Minor refactoring and code styling cleanup