### PR TITLE
Upgraded stoarge to fix issue #38

### DIFF
--- a/MediaServices.Client.Extensions.Tests/App.config
+++ b/MediaServices.Client.Extensions.Tests/App.config
@@ -31,7 +31,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.0.3.0" newVersion="3.0.3.0" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.2.0" newVersion="5.0.2.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />

--- a/MediaServices.Client.Extensions.Tests/MediaServices.Client.Extensions.Tests.csproj
+++ b/MediaServices.Client.Extensions.Tests/MediaServices.Client.Extensions.Tests.csproj
@@ -35,6 +35,9 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Azure.KeyVault.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Data.Edm.5.6.4\lib\net40\Microsoft.Data.Edm.dll</HintPath>
       <Private>True</Private>
@@ -67,9 +70,8 @@
       <HintPath>..\packages\windowsazure.mediaservices.4.0.0.4\lib\net45\Microsoft.WindowsAzure.MediaServices.Client.Common.FileEncryption.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\WindowsAzure.Storage.4.3.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=5.0.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\WindowsAzure.Storage.5.0.2\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/MediaServices.Client.Extensions.Tests/packages.config
+++ b/MediaServices.Client.Extensions.Tests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net45" />
@@ -10,5 +11,5 @@
   <package id="System.Spatial" version="5.6.4" targetFramework="net45" />
   <package id="TransientFaultHandling.Core" version="5.1.1209.1" targetFramework="net40" />
   <package id="windowsazure.mediaservices" version="4.0.0.4" targetFramework="net45" />
-  <package id="WindowsAzure.Storage" version="4.3.0.0" targetFramework="net40" />
+  <package id="WindowsAzure.Storage" version="5.0.2" targetFramework="net45" />
 </packages>

--- a/MediaServices.Client.Extensions/App.config
+++ b/MediaServices.Client.Extensions/App.config
@@ -19,7 +19,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.0.3.0" newVersion="3.0.3.0" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.2.0" newVersion="5.0.2.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />

--- a/MediaServices.Client.Extensions/CopyBlobHelpers.cs
+++ b/MediaServices.Client.Extensions/CopyBlobHelpers.cs
@@ -77,7 +77,7 @@ namespace Microsoft.WindowsAzure.MediaServices.Client
         /// <returns>A <see cref="System.Threading.Tasks.Task"/> instance for the copy blob operation from <paramref name="sourceBlob"/> to <paramref name="destinationBlob"/>.</returns>
         public static async Task CopyBlobAsync(CloudBlockBlob sourceBlob, CloudBlockBlob destinationBlob, BlobRequestOptions options, CancellationToken cancellationToken)
         {
-            await destinationBlob.StartCopyFromBlobAsync(sourceBlob, null, null, options, null, cancellationToken).ConfigureAwait(false);
+            await destinationBlob.StartCopyAsync(sourceBlob, null, null, options, null, cancellationToken).ConfigureAwait(false);
 
             CopyState copyState = destinationBlob.CopyState;
             while (copyState == null || copyState.Status == CopyStatus.Pending)

--- a/MediaServices.Client.Extensions/MediaServices.Client.Extensions.csproj
+++ b/MediaServices.Client.Extensions/MediaServices.Client.Extensions.csproj
@@ -50,6 +50,9 @@
     <AssemblyOriginatorKeyFile>..\MSSharedLibSN1024.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Azure.KeyVault.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Data.Edm.5.6.4\lib\net40\Microsoft.Data.Edm.dll</HintPath>
       <Private>True</Private>
@@ -82,9 +85,8 @@
       <HintPath>..\packages\windowsazure.mediaservices.4.0.0.4\lib\net45\Microsoft.WindowsAzure.MediaServices.Client.Common.FileEncryption.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\WindowsAzure.Storage.4.3.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=5.0.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\WindowsAzure.Storage.5.0.2\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/MediaServices.Client.Extensions/packages.config
+++ b/MediaServices.Client.Extensions/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net45" />
@@ -9,5 +10,5 @@
   <package id="System.Spatial" version="5.6.4" targetFramework="net45" />
   <package id="TransientFaultHandling.Core" version="5.1.1209.1" targetFramework="net45" />
   <package id="windowsazure.mediaservices" version="4.0.0.1" targetFramework="net45" />
-  <package id="WindowsAzure.Storage" version="4.3.0" targetFramework="net45" />
+  <package id="WindowsAzure.Storage" version="5.0.2" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Upgraded Microsoft.WindowsAzure.Storage to version 5.0.2.0 to fix Issue #38, Method not found error when using Copy extension methods